### PR TITLE
Feat/70/respond with email verified

### DIFF
--- a/backend/.sqlc/migrations/20241203212121_alter_users_add_email_verified.sql
+++ b/backend/.sqlc/migrations/20241203212121_alter_users_add_email_verified.sql
@@ -1,0 +1,15 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- by default, goose runs in transactions
+
+ALTER TABLE users ADD COLUMN email_verified BOOLEAN NOT NULL DEFAULT false;
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+ALTER TABLE users DROP COLUMN email_verified;
+
+-- +goose StatementEnd

--- a/backend/.sqlc/queries/users.sql
+++ b/backend/.sqlc/queries/users.sql
@@ -2,11 +2,9 @@
 INSERT INTO users (
     email,
     password_hash,
-    first_name,
-    last_name,
     role
 ) VALUES (
-    $1, $2, $3, $4, $5
+    $1, $2, $3
 ) RETURNING *;
 
 -- name: GetUserByEmail :one

--- a/backend/db/company_questions_answers.sql.go
+++ b/backend/db/company_questions_answers.sql.go
@@ -65,6 +65,17 @@ func (q *Queries) CreateQuestion(ctx context.Context, questionText string) (Ques
 	return i, err
 }
 
+const deleteQuestion = `-- name: DeleteQuestion :exec
+UPDATE questions 
+SET deleted_at = NOW()
+WHERE id = $1 AND deleted_at IS NULL
+`
+
+func (q *Queries) DeleteQuestion(ctx context.Context, id string) error {
+	_, err := q.db.Exec(ctx, deleteQuestion, id)
+	return err
+}
+
 const getCompanyAnswer = `-- name: GetCompanyAnswer :one
 SELECT 
     cqa.id, cqa.company_id, cqa.question_id, cqa.answer_text, cqa.created_at, cqa.updated_at, cqa.deleted_at,

--- a/backend/db/models.go
+++ b/backend/db/models.go
@@ -234,4 +234,5 @@ type User struct {
 	CreatedAt     pgtype.Timestamp
 	UpdatedAt     pgtype.Timestamp
 	Role          UserRole
+	EmailVerified bool
 }

--- a/backend/db/users.sql.go
+++ b/backend/db/users.sql.go
@@ -13,30 +13,20 @@ const createUser = `-- name: CreateUser :one
 INSERT INTO users (
     email,
     password_hash,
-    first_name,
-    last_name,
     role
 ) VALUES (
-    $1, $2, $3, $4, $5
-) RETURNING id, email, password_hash, first_name, last_name, wallet_address, created_at, updated_at, role
+    $1, $2, $3
+) RETURNING id, email, password_hash, first_name, last_name, wallet_address, created_at, updated_at, role, email_verified
 `
 
 type CreateUserParams struct {
 	Email        string
 	PasswordHash string
-	FirstName    *string
-	LastName     *string
 	Role         UserRole
 }
 
 func (q *Queries) CreateUser(ctx context.Context, arg CreateUserParams) (User, error) {
-	row := q.db.QueryRow(ctx, createUser,
-		arg.Email,
-		arg.PasswordHash,
-		arg.FirstName,
-		arg.LastName,
-		arg.Role,
-	)
+	row := q.db.QueryRow(ctx, createUser, arg.Email, arg.PasswordHash, arg.Role)
 	var i User
 	err := row.Scan(
 		&i.ID,
@@ -48,12 +38,13 @@ func (q *Queries) CreateUser(ctx context.Context, arg CreateUserParams) (User, e
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.Role,
+		&i.EmailVerified,
 	)
 	return i, err
 }
 
 const getUserByEmail = `-- name: GetUserByEmail :one
-SELECT id, email, password_hash, first_name, last_name, wallet_address, created_at, updated_at, role FROM users
+SELECT id, email, password_hash, first_name, last_name, wallet_address, created_at, updated_at, role, email_verified FROM users
 WHERE email = $1 LIMIT 1
 `
 
@@ -70,12 +61,13 @@ func (q *Queries) GetUserByEmail(ctx context.Context, email string) (User, error
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.Role,
+		&i.EmailVerified,
 	)
 	return i, err
 }
 
 const getUserByID = `-- name: GetUserByID :one
-SELECT id, email, password_hash, first_name, last_name, wallet_address, created_at, updated_at, role FROM users
+SELECT id, email, password_hash, first_name, last_name, wallet_address, created_at, updated_at, role, email_verified FROM users
 WHERE id = $1 LIMIT 1
 `
 
@@ -92,6 +84,7 @@ func (q *Queries) GetUserByID(ctx context.Context, id string) (User, error) {
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.Role,
+		&i.EmailVerified,
 	)
 	return i, err
 }

--- a/backend/internal/server/auth.go
+++ b/backend/internal/server/auth.go
@@ -46,8 +46,6 @@ func (s *Server) handleSignup(c echo.Context) error {
 	user, err := s.queries.CreateUser(ctx, db.CreateUserParams{
 		Email:        req.Email,
 		PasswordHash: string(hashedPassword),
-		FirstName:    &req.FirstName,
-		LastName:     &req.LastName,
 		Role:         req.Role,
 	})
 	if err != nil {
@@ -65,10 +63,11 @@ func (s *Server) handleSignup(c echo.Context) error {
 		User: User{
 			ID:            user.ID,
 			Email:         user.Email,
-			FirstName:     *user.FirstName,
-			LastName:      *user.LastName,
+			FirstName:     user.FirstName,
+			LastName:      user.LastName,
 			Role:          user.Role,
 			WalletAddress: user.WalletAddress,
+			EmailVerified: user.EmailVerified,
 		},
 	})
 }
@@ -103,10 +102,11 @@ func (s *Server) handleSignin(c echo.Context) error {
 		User: User{
 			ID:            user.ID,
 			Email:         user.Email,
-			FirstName:     *user.FirstName,
-			LastName:      *user.LastName,
+			FirstName:     user.FirstName,
+			LastName:      user.LastName,
 			Role:          user.Role,
 			WalletAddress: user.WalletAddress,
+			EmailVerified: user.EmailVerified,
 		},
 	})
 }

--- a/backend/internal/server/auth_test.go
+++ b/backend/internal/server/auth_test.go
@@ -39,11 +39,9 @@ func TestAuth(t *testing.T) {
 	// test signup
 	t.Run("signup", func(t *testing.T) {
 		payload := SignupRequest{
-			Email:     "test@example.com",
-			Password:  "password123",
-			FirstName: "Test",
-			LastName:  "User",
-			Role:      "startup_owner",
+			Email:    "test@example.com",
+			Password: "password123",
+			Role:     "startup_owner",
 		}
 		body, _ := json.Marshal(payload)
 
@@ -66,11 +64,9 @@ func TestAuth(t *testing.T) {
 	// test duplicate email
 	t.Run("duplicate email", func(t *testing.T) {
 		payload := SignupRequest{
-			Email:     "test@example.com",
-			Password:  "password123",
-			FirstName: "Test",
-			LastName:  "User",
-			Role:      "startup_owner",
+			Email:    "test@example.com",
+			Password: "password123",
+			Role:     "startup_owner",
 		}
 		body, _ := json.Marshal(payload)
 

--- a/backend/internal/server/types.go
+++ b/backend/internal/server/types.go
@@ -44,11 +44,9 @@ type CreateResourceRequestRequest struct {
 }
 
 type SignupRequest struct {
-	Email     string      `json:"email" validate:"required,email"`
-	Password  string      `json:"password" validate:"required,min=8"`
-	FirstName string      `json:"first_name" validate:"required"`
-	LastName  string      `json:"last_name" validate:"required"`
-	Role      db.UserRole `json:"role" validate:"required,valid_user_role,non_admin_role"`
+	Email    string      `json:"email" validate:"required,email"`
+	Password string      `json:"password" validate:"required,min=8"`
+	Role     db.UserRole `json:"role" validate:"required,valid_user_role,non_admin_role"`
 }
 
 type SigninRequest struct {
@@ -65,10 +63,11 @@ type AuthResponse struct {
 type User struct {
 	ID            string      `json:"id"`
 	Email         string      `json:"email"`
-	FirstName     string      `json:"first_name"`
-	LastName      string      `json:"last_name"`
+	FirstName     *string     `json:"first_name"`
+	LastName      *string     `json:"last_name"`
 	Role          db.UserRole `json:"role"`
 	WalletAddress *string     `json:"wallet_address,omitempty"`
+	EmailVerified bool        `json:"email_verified"`
 }
 
 type CreateCompanyFinancialsRequest struct {


### PR DESCRIPTION
Add a migration that adds a new `email_verified` column to the users table.

Now for signups, there is no need to include the first and last name. That would be for the onboarding process to complete their profile.