### PR TITLE
Add 'withdrawn' state to project status enum

### DIFF
--- a/backend/.sqlc/migrations/20241215194302_initial_schema.sql
+++ b/backend/.sqlc/migrations/20241215194302_initial_schema.sql
@@ -14,7 +14,8 @@ CREATE TYPE project_status AS ENUM (
     'draft',
     'pending',
     'verified',
-    'declined'
+    'declined',
+    'withdrawn'
 );
 
 CREATE TABLE IF NOT EXISTS users (


### PR DESCRIPTION
## Checklist
Before opening this PR, make sure the PR:
- [x] Has an **assignee or group of assignees**.
- [x] Is **labelled properly**.
- [x] Has the **SPUR project assigned to it**.
- [x] Has an **assigned milestone**.

Additionally, make sure that:
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.

## Description
Added 'withdrawn' as a new valid state to the project_status enum used to allow users to void/withdraw their applications after submission.

## Linked Issues
- Fixes #200 

## Type of Change
Please delete options that are not relevant:
- [x] New feature (non-breaking change which adds functionality).
