### PR TITLE
Feat/185/verify email status route

### DIFF
--- a/backend/.sqlc/queries/users.sql
+++ b/backend/.sqlc/queries/users.sql
@@ -1,4 +1,7 @@
 -- name: GetUserByID :one
 SELECT id, email, role, email_verified, token_salt
 FROM users 
-WHERE id = $1; 
+WHERE id = $1;
+
+-- name: GetUserEmailVerifiedStatusByEmail :one
+SELECT email_verified FROM users WHERE email = $1;

--- a/backend/db/helpers.go
+++ b/backend/db/helpers.go
@@ -1,0 +1,10 @@
+package db
+
+import "github.com/jackc/pgx/v5"
+
+/*
+Check if the returned error from a query that is expecting row(s) but none returned.
+*/
+func IsNoRowsErr(err error) bool {
+	return err == pgx.ErrNoRows
+}

--- a/backend/db/models.go
+++ b/backend/db/models.go
@@ -14,10 +14,11 @@ import (
 type ProjectStatus string
 
 const (
-	ProjectStatusDraft    ProjectStatus = "draft"
-	ProjectStatusPending  ProjectStatus = "pending"
-	ProjectStatusVerified ProjectStatus = "verified"
-	ProjectStatusDeclined ProjectStatus = "declined"
+	ProjectStatusDraft     ProjectStatus = "draft"
+	ProjectStatusPending   ProjectStatus = "pending"
+	ProjectStatusVerified  ProjectStatus = "verified"
+	ProjectStatusDeclined  ProjectStatus = "declined"
+	ProjectStatusWithdrawn ProjectStatus = "withdrawn"
 )
 
 func (e *ProjectStatus) Scan(src interface{}) error {
@@ -60,7 +61,8 @@ func (e ProjectStatus) Valid() bool {
 	case ProjectStatusDraft,
 		ProjectStatusPending,
 		ProjectStatusVerified,
-		ProjectStatusDeclined:
+		ProjectStatusDeclined,
+		ProjectStatusWithdrawn:
 		return true
 	}
 	return false
@@ -72,6 +74,7 @@ func AllProjectStatusValues() []ProjectStatus {
 		ProjectStatusPending,
 		ProjectStatusVerified,
 		ProjectStatusDeclined,
+		ProjectStatusWithdrawn,
 	}
 }
 

--- a/backend/db/users.sql.go
+++ b/backend/db/users.sql.go
@@ -35,3 +35,14 @@ func (q *Queries) GetUserByID(ctx context.Context, id string) (GetUserByIDRow, e
 	)
 	return i, err
 }
+
+const getUserEmailVerifiedStatusByEmail = `-- name: GetUserEmailVerifiedStatusByEmail :one
+SELECT email_verified FROM users WHERE email = $1
+`
+
+func (q *Queries) GetUserEmailVerifiedStatusByEmail(ctx context.Context, email string) (bool, error) {
+	row := q.db.QueryRow(ctx, getUserEmailVerifiedStatusByEmail, email)
+	var email_verified bool
+	err := row.Scan(&email_verified)
+	return email_verified, err
+}

--- a/backend/internal/v1/setup.go
+++ b/backend/internal/v1/setup.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"KonferCA/SPUR/internal/interfaces"
+	"KonferCA/SPUR/internal/v1/v1_auth"
 	"KonferCA/SPUR/internal/v1/v1_health"
 )
 
@@ -9,4 +10,5 @@ func SetupRoutes(s interfaces.CoreServer) {
 	e := s.GetEcho()
 	g := e.Group("/api/v1")
 	v1_health.SetupHealthcheckRoutes(g, s)
+	v1_auth.SetupAuthRoutes(g, s)
 }

--- a/backend/internal/v1/v1_auth/auth.go
+++ b/backend/internal/v1/v1_auth/auth.go
@@ -1,1 +1,1 @@
-package v1auth
+package v1_auth

--- a/backend/internal/v1/v1_auth/auth.go
+++ b/backend/internal/v1/v1_auth/auth.go
@@ -1,1 +1,34 @@
 package v1_auth
+
+import (
+	"KonferCA/SPUR/db"
+	"KonferCA/SPUR/internal/middleware"
+	"KonferCA/SPUR/internal/v1/v1_common"
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+)
+
+/*
+Simple route handler that just returns whether the email has been verified or not in JSON body.
+*/
+func (h *Handler) handleEmailVerificationStatus(c echo.Context) error {
+	email := c.QueryParam("email")
+	if email == "" {
+		return v1_common.Fail(c, http.StatusBadRequest, "Missing required query parameter: 'email'", nil)
+	}
+
+	ctx := c.Request().Context()
+	logger := middleware.GetLogger(c)
+	pool := h.server.GetDB()
+
+	verified, err := db.New(pool).GetUserEmailVerifiedStatusByEmail(ctx, email)
+	if err != nil {
+		// manually log the error for debugging purposes later
+		// but the client does not need to know any specifics
+		// and instead just know whether it is verified or not.
+		logger.Error(err, "Something went wrong when querying user to check email verification status using email as identifier.")
+	}
+
+	return c.JSON(http.StatusOK, EmailVerifiedStatusResponse{Verified: err == nil && verified})
+}

--- a/backend/internal/v1/v1_auth/auth.go
+++ b/backend/internal/v1/v1_auth/auth.go
@@ -2,8 +2,8 @@ package v1_auth
 
 import (
 	"KonferCA/SPUR/db"
-	"KonferCA/SPUR/internal/middleware"
 	"KonferCA/SPUR/internal/v1/v1_common"
+	"errors"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
@@ -13,22 +13,10 @@ import (
 Simple route handler that just returns whether the email has been verified or not in JSON body.
 */
 func (h *Handler) handleEmailVerificationStatus(c echo.Context) error {
-	email := c.QueryParam("email")
-	if email == "" {
-		return v1_common.Fail(c, http.StatusBadRequest, "Missing required query parameter: 'email'", nil)
+	user, ok := c.Get("user").(*db.GetUserByIDRow)
+	if !ok {
+		return v1_common.Fail(c, http.StatusInternalServerError, "", errors.New("Failed to cast user type from context that should have been set by Auth middleware."))
 	}
 
-	ctx := c.Request().Context()
-	logger := middleware.GetLogger(c)
-	pool := h.server.GetDB()
-
-	verified, err := db.New(pool).GetUserEmailVerifiedStatusByEmail(ctx, email)
-	if err != nil {
-		// manually log the error for debugging purposes later
-		// but the client does not need to know any specifics
-		// and instead just know whether it is verified or not.
-		logger.Error(err, "Something went wrong when querying user to check email verification status using email as identifier.")
-	}
-
-	return c.JSON(http.StatusOK, EmailVerifiedStatusResponse{Verified: err == nil && verified})
+	return c.JSON(http.StatusOK, EmailVerifiedStatusResponse{Verified: user.EmailVerified})
 }

--- a/backend/internal/v1/v1_auth/routes.go
+++ b/backend/internal/v1/v1_auth/routes.go
@@ -1,12 +1,21 @@
 package v1_auth
 
 import (
+	"KonferCA/SPUR/db"
 	"KonferCA/SPUR/internal/interfaces"
+	"KonferCA/SPUR/internal/middleware"
 
 	"github.com/labstack/echo/v4"
 )
 
+/*
+Sets up the V1 auth routes.
+*/
 func SetupAuthRoutes(e *echo.Group, s interfaces.CoreServer) {
 	h := Handler{server: s}
-	e.GET("/auth/ami-verified", h.handleEmailVerificationStatus)
+	e.GET(
+		"/auth/ami-verified",
+		h.handleEmailVerificationStatus,
+		middleware.Auth(s.GetDB(), db.UserRoleStartupOwner, db.UserRoleAdmin, db.UserRoleStartupOwner),
+	)
 }

--- a/backend/internal/v1/v1_auth/routes.go
+++ b/backend/internal/v1/v1_auth/routes.go
@@ -1,1 +1,1 @@
-package v1auth
+package v1_auth

--- a/backend/internal/v1/v1_auth/routes.go
+++ b/backend/internal/v1/v1_auth/routes.go
@@ -1,1 +1,12 @@
 package v1_auth
+
+import (
+	"KonferCA/SPUR/internal/interfaces"
+
+	"github.com/labstack/echo/v4"
+)
+
+func SetupAuthRoutes(e *echo.Group, s interfaces.CoreServer) {
+	h := Handler{server: s}
+	e.GET("/auth/ami-verified", h.handleEmailVerificationStatus)
+}

--- a/backend/internal/v1/v1_auth/types.go
+++ b/backend/internal/v1/v1_auth/types.go
@@ -1,1 +1,1 @@
-package v1auth
+package v1_auth

--- a/backend/internal/v1/v1_auth/types.go
+++ b/backend/internal/v1/v1_auth/types.go
@@ -8,3 +8,10 @@ Main Handler struct for V1 auth routes.
 type Handler struct {
 	server interfaces.CoreServer
 }
+
+/*
+Response body for route /auth/ami-verified
+*/
+type EmailVerifiedStatusResponse struct {
+	Verified bool `json:"verified"`
+}

--- a/backend/internal/v1/v1_auth/types.go
+++ b/backend/internal/v1/v1_auth/types.go
@@ -1,1 +1,10 @@
 package v1_auth
+
+import "KonferCA/SPUR/internal/interfaces"
+
+/*
+Main Handler struct for V1 auth routes.
+*/
+type Handler struct {
+	server interfaces.CoreServer
+}

--- a/backend/internal/v1/v1_common/constants.go
+++ b/backend/internal/v1/v1_common/constants.go
@@ -1,1 +1,1 @@
-package v1common
+package v1_common

--- a/backend/internal/v1/v1_common/errors.go
+++ b/backend/internal/v1/v1_common/errors.go
@@ -1,1 +1,1 @@
-package v1common
+package v1_common

--- a/backend/internal/v1/v1_common/helpers.go
+++ b/backend/internal/v1/v1_common/helpers.go
@@ -1,4 +1,4 @@
-package v1common
+package v1_common
 
 import (
 	"net/http"
@@ -14,10 +14,10 @@ Example:
 
 	func handler(c echo.Context) error
 	    // some code...
-	    return success(c, http.StatusOk, "Something")
+	    return Success(c, http.StatusOk, "Something")
 	}
 */
-func success(c echo.Context, code int, message string) error {
+func Success(c echo.Context, code int, message string) error {
 	if message == "" {
 		message = http.StatusText(code)
 	}
@@ -37,10 +37,10 @@ Example:
 
 	func handler(c echo.Context) error
 	    // some code...
-	    return fail(c, http.StatusNotFound, "Something not found", err)
+	    return Fail(c, http.StatusNotFound, "Something not found", err)
 	}
 */
-func fail(c echo.Context, code int, publicErrMsg string, internalErr error) error {
+func Fail(c echo.Context, code int, publicErrMsg string, internalErr error) error {
 	c.Set("internal_error", internalErr)
 	if publicErrMsg == "" {
 		publicErrMsg = http.StatusText(code)

--- a/backend/internal/v1/v1_common/helpers_test.go
+++ b/backend/internal/v1/v1_common/helpers_test.go
@@ -1,4 +1,4 @@
-package v1common
+package v1_common
 
 import (
 	"encoding/json"
@@ -18,7 +18,7 @@ func TestRequestResponders(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
 		rec := httptest.NewRecorder()
 		c := e.NewContext(req, rec)
-		err := success(c, http.StatusOK, "test")
+		err := Success(c, http.StatusOK, "test")
 		assert.NoError(t, err)
 		data, err := io.ReadAll(rec.Body)
 		assert.NoError(t, err)
@@ -34,7 +34,7 @@ func TestRequestResponders(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
 		rec := httptest.NewRecorder()
 		c := e.NewContext(req, rec)
-		err := success(c, http.StatusOK, "")
+		err := Success(c, http.StatusOK, "")
 		assert.NoError(t, err)
 		data, err := io.ReadAll(rec.Body)
 		assert.NoError(t, err)
@@ -51,7 +51,7 @@ func TestRequestResponders(t *testing.T) {
 		rec := httptest.NewRecorder()
 		c := e.NewContext(req, rec)
 		testErr := errors.New("test-error")
-		err, ok := fail(c, http.StatusBadRequest, "test", testErr).(*echo.HTTPError)
+		err, ok := Fail(c, http.StatusBadRequest, "test", testErr).(*echo.HTTPError)
 		assert.True(t, ok)
 		assert.Equal(t, err.Code, http.StatusBadRequest)
 		assert.Equal(t, err.Message, "test")
@@ -66,7 +66,7 @@ func TestRequestResponders(t *testing.T) {
 		rec := httptest.NewRecorder()
 		c := e.NewContext(req, rec)
 		testErr := errors.New("test-error")
-		err, ok := fail(c, http.StatusBadRequest, "", testErr).(*echo.HTTPError)
+		err, ok := Fail(c, http.StatusBadRequest, "", testErr).(*echo.HTTPError)
 		assert.True(t, ok)
 		assert.Equal(t, err.Code, http.StatusBadRequest)
 		assert.Equal(t, err.Message, http.StatusText(http.StatusBadRequest))
@@ -80,7 +80,7 @@ func TestRequestResponders(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
 		rec := httptest.NewRecorder()
 		c := e.NewContext(req, rec)
-		err, ok := fail(c, http.StatusBadRequest, "", nil).(*echo.HTTPError)
+		err, ok := Fail(c, http.StatusBadRequest, "", nil).(*echo.HTTPError)
 		assert.True(t, ok)
 		assert.Equal(t, err.Code, http.StatusBadRequest)
 		assert.Equal(t, err.Message, http.StatusText(http.StatusBadRequest))

--- a/backend/internal/v1/v1_common/request.go
+++ b/backend/internal/v1/v1_common/request.go
@@ -1,1 +1,1 @@
-package v1common
+package v1_common

--- a/backend/internal/v1/v1_common/response.go
+++ b/backend/internal/v1/v1_common/response.go
@@ -1,4 +1,4 @@
-package v1common
+package v1_common
 
 /*
 Use this for any json response that just needs a simple message field.

--- a/backend/internal/v1/v1_common/types.go
+++ b/backend/internal/v1/v1_common/types.go
@@ -1,1 +1,1 @@
-package v1common
+package v1_common


### PR DESCRIPTION
## Description
New route that clients (frontend) can hit to check the latest `email verified` status of a user. The route is protected so that not everyone can just query the status of any user.

MAYBE BREAKING: I updated the v1_common package name since it was overlooked in previous PR and actually exported the helper functions.

## Linked Issues
- Closes #185 

## Testing
- Add new black box testing for the route under `tests/server_test.go`

## Checklist
Before opening this PR, make sure the PR:
- [x] Has an **assignee or group of assignees**.
- [x] Has a **reviewer or a group of reviewers**.
- [x] Is **labelled properly**.
- [x] Has the **SPUR project assigned to it**.
- [x] Has an **assigned milestone**.

Additionally, make sure that:
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.