### PR TITLE
add logout route + tests

### DIFF
--- a/backend/internal/v1/v1_auth/auth.go
+++ b/backend/internal/v1/v1_auth/auth.go
@@ -319,3 +319,11 @@ func (h *Handler) handleVerifyCookie(c echo.Context) error {
 		},
 	})
 }
+
+/*
+Handle incoming logout requests. This will empty out the refresh token cookie.
+*/
+func (h *Handler) handleLogout(c echo.Context) error {
+	unsetRefreshTokenCookie(c)
+	return v1_common.Success(c, http.StatusOK, "Successfully logged out.")
+}

--- a/backend/internal/v1/v1_auth/cookies.go
+++ b/backend/internal/v1/v1_auth/cookies.go
@@ -43,3 +43,16 @@ func setRefreshTokenCookie(c echo.Context, value string) {
 	cookie.Value = value
 	c.SetCookie(cookie)
 }
+
+/*
+Unsets the refresh token cookie. Make the right configuration
+that tells the browser to remove the cookie.
+*/
+func unsetRefreshTokenCookie(c echo.Context) {
+	cookie := getRefreshTokenCookieConfig()
+	cookie.Value = ""
+	// expires and max-age tells the browser to remove the cookie
+	cookie.Expires = time.Now().UTC()
+	cookie.MaxAge = -1
+	c.SetCookie(cookie)
+}

--- a/backend/internal/v1/v1_auth/routes.go
+++ b/backend/internal/v1/v1_auth/routes.go
@@ -40,4 +40,5 @@ func SetupAuthRoutes(e *echo.Group, s interfaces.CoreServer) {
 	e.GET("/auth/verify", h.handleVerifyCookie)
 	e.GET("/auth/verify-email", h.handleVerifyEmail, authLimiter.RateLimit())
 	e.POST("/auth/register", h.handleRegister, authLimiter.RateLimit())
+	e.GET("/auth/logout", h.handleLogout, authLimiter.RateLimit())
 }


### PR DESCRIPTION
## Description
A logout route that unsets the refresh token cookie.

## Linked Issues
- #182 

## Testing
- add new test for the logout route in `tests/server_test.go`

## Checklist
Before opening this PR, make sure the PR:
- [x] Has an **assignee or group of assignees**.
- [x] Has a **reviewer or a group of reviewers**.
- [x] Is **labelled properly**.
- [x] Has the **SPUR project assigned to it**.
- [x] Has an **assigned milestone**.

Additionally, make sure that:
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.