### PR TITLE
Change logout route request method from GET to POST

### DIFF
--- a/backend/internal/tests/server_test.go
+++ b/backend/internal/tests/server_test.go
@@ -486,7 +486,7 @@ func TestServer(t *testing.T) {
 			assert.NotNil(t, tokenCookie)
 			assert.NotEmpty(t, tokenCookie.Value)
 
-			req = httptest.NewRequest(http.MethodGet, "/api/v1/auth/logout", nil)
+			req = httptest.NewRequest(http.MethodPost, "/api/v1/auth/logout", nil)
 			req.AddCookie(tokenCookie)
 			rec = httptest.NewRecorder()
 

--- a/backend/internal/v1/v1_auth/routes.go
+++ b/backend/internal/v1/v1_auth/routes.go
@@ -40,5 +40,5 @@ func SetupAuthRoutes(e *echo.Group, s interfaces.CoreServer) {
 	e.GET("/auth/verify", h.handleVerifyCookie)
 	e.GET("/auth/verify-email", h.handleVerifyEmail, authLimiter.RateLimit())
 	e.POST("/auth/register", h.handleRegister, authLimiter.RateLimit())
-	e.GET("/auth/logout", h.handleLogout, authLimiter.RateLimit())
+	e.POST("/auth/logout", h.handleLogout, authLimiter.RateLimit())
 }


### PR DESCRIPTION
## Description
Updated the logout route request method from GET to POST in order to prevent unwanted logouts caused by pre-fetching by browsers.

## Linked Issues
- Fixes #292 

## Testing
- Old tests have been updated to use POST method.

## Checklist
Before opening this PR, make sure the PR:
- [x] Has an **assignee or group of assignees**.
- [x] Has a **reviewer or a group of reviewers**.
- [x] Is **labelled properly**.
- [x] Has the **SPUR project assigned to it**.
- [x] Has an **assigned milestone**.

Additionally, make sure that:
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.