### PR TITLE
Update error handling to return APIError

### DIFF
--- a/backend/internal/middleware/rate_limit.go
+++ b/backend/internal/middleware/rate_limit.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"KonferCA/SPUR/internal/v1/v1_common"
 	"net/http"
 	"sync"
 	"time"
@@ -122,9 +123,11 @@ func (rl *RateLimiter) RateLimit() echo.MiddlewareFunc {
 					Dur("remaining", remaining).
 					Msg("request blocked: rate limit exceeded")
 
-				return echo.NewHTTPError(
+				return v1_common.Fail(
+					c,
 					http.StatusTooManyRequests,
 					"too many requests, please try again in "+remaining.Round(time.Second).String(),
+					nil,
 				)
 			}
 
@@ -151,9 +154,11 @@ func (rl *RateLimiter) RateLimit() echo.MiddlewareFunc {
 					Dur("block_duration", blockDuration).
 					Msg("IP blocked: rate limit exceeded")
 
-				return echo.NewHTTPError(
+				return v1_common.Fail(
+					c,
 					http.StatusTooManyRequests,
 					"too many requests, please try again in "+blockDuration.Round(time.Second).String(),
+					nil,
 				)
 			}
 

--- a/backend/internal/middleware/request_validator.go
+++ b/backend/internal/middleware/request_validator.go
@@ -2,15 +2,14 @@ package middleware
 
 import (
 	"KonferCA/SPUR/db"
+	"KonferCA/SPUR/internal/v1/v1_common"
 	"fmt"
-	"net/http"
 	"os"
 	"reflect"
 	"regexp"
 	"strings"
 
 	"github.com/go-playground/validator/v10"
-	"github.com/labstack/echo/v4"
 	"github.com/rs/zerolog/log"
 )
 
@@ -67,7 +66,7 @@ func (cv *CustomValidator) Validate(i interface{}) error {
 	if err := cv.validator.Struct(i); err != nil {
 		log.Error().Err(err).Msg("validation error")
 
-		return echo.NewHTTPError(http.StatusBadRequest, formatValidationErrors(err))
+		return v1_common.NewValidationError(formatValidationErrors(err))
 	}
 
 	return nil

--- a/backend/internal/tests/jwt_test.go
+++ b/backend/internal/tests/jwt_test.go
@@ -1,125 +1,126 @@
 package tests
 
-// import (
-// 	"os"
-// 	"testing"
-// 	"time"
-//
-// 	"KonferCA/SPUR/db"
-//
-// 	"github.com/stretchr/testify/assert"
-// )
-//
-// func TestJWT(t *testing.T) {
-// 	// setup env
-// 	os.Setenv("JWT_SECRET", "secret")
-// 	os.Setenv("JWT_SECRET_VERIFY_EMAIL", "test-secret")
-//
-// 	userID := "some-user-id"
-// 	role := db.UserRole("user")
-// 	salt := []byte("test-salt")
-//
-// 	t.Run("token salt invalidation", func(t *testing.T) {
-// 		// Generate initial salt
-// 		initialSalt := []byte("initial-salt")
-//
-// 		// Generate tokens with initial salt
-// 		accessToken, refreshToken, err := GenerateWithSalt(userID, role, initialSalt)
-// 		assert.Nil(t, err)
-// 		assert.NotEmpty(t, accessToken)
-// 		assert.NotEmpty(t, refreshToken)
-//
-// 		// Verify tokens work with initial salt
-// 		claims, err := VerifyTokenWithSalt(accessToken, initialSalt)
-// 		assert.Nil(t, err)
-// 		assert.Equal(t, claims.UserID, userID)
-// 		assert.Equal(t, claims.Role, role)
-// 		assert.Equal(t, claims.TokenType, ACCESS_TOKEN_TYPE)
-//
-// 		// Change salt (simulating token invalidation)
-// 		newSalt := []byte("new-salt")
-//
-// 		// Old tokens should fail verification with new salt
-// 		_, err = VerifyTokenWithSalt(accessToken, newSalt)
-// 		assert.NotNil(t, err, "Token should be invalid with new salt")
-//
-// 		// Generate new tokens with new salt
-// 		newAccessToken, newRefreshToken, err := GenerateWithSalt(userID, role, newSalt)
-// 		assert.Nil(t, err)
-// 		assert.NotEmpty(t, newAccessToken)
-// 		assert.NotEmpty(t, newRefreshToken)
-//
-// 		// New tokens should work with new salt
-// 		claims, err = VerifyTokenWithSalt(newAccessToken, newSalt)
-// 		assert.Nil(t, err)
-// 		assert.Equal(t, claims.UserID, userID)
-// 	})
-//
-// 	t.Run("two-step verification", func(t *testing.T) {
-// 		salt := []byte("test-salt")
-//
-// 		// Generate a token
-// 		accessToken, _, err := GenerateWithSalt(userID, role, salt)
-// 		assert.Nil(t, err)
-//
-// 		// Step 1: Parse claims without verification
-// 		unverifiedClaims, err := ParseUnverifiedClaims(accessToken)
-// 		assert.Nil(t, err)
-// 		assert.Equal(t, userID, unverifiedClaims.UserID)
-//
-// 		// Step 2: Verify with salt
-// 		verifiedClaims, err := VerifyTokenWithSalt(accessToken, salt)
-// 		assert.Nil(t, err)
-// 		assert.Equal(t, userID, verifiedClaims.UserID)
-//
-// 		// Try to verify with wrong salt
-// 		wrongSalt := []byte("wrong-salt")
-// 		_, err = VerifyTokenWithSalt(accessToken, wrongSalt)
-// 		assert.NotNil(t, err, "Token should be invalid with wrong salt")
-// 	})
-//
-// 	t.Run("generate access token", func(t *testing.T) {
-// 		accessToken, _, err := GenerateWithSalt(userID, role, salt)
-// 		assert.Nil(t, err)
-// 		assert.NotEmpty(t, accessToken)
-// 		claims, err := VerifyTokenWithSalt(accessToken, salt)
-// 		assert.Nil(t, err)
-// 		assert.Equal(t, claims.UserID, userID)
-// 		assert.Equal(t, claims.Role, role)
-// 		assert.Equal(t, claims.TokenType, ACCESS_TOKEN_TYPE)
-// 	})
-//
-// 	t.Run("generate refresh token", func(t *testing.T) {
-// 		_, refreshToken, err := GenerateWithSalt(userID, role, salt)
-// 		assert.Nil(t, err)
-// 		assert.NotEmpty(t, refreshToken)
-// 		claims, err := VerifyTokenWithSalt(refreshToken, salt)
-// 		assert.Nil(t, err)
-// 		assert.Equal(t, claims.UserID, userID)
-// 		assert.Equal(t, claims.Role, role)
-// 		assert.Equal(t, claims.TokenType, REFRESH_TOKEN_TYPE)
-// 	})
-//
-// 	t.Run("verify email token", func(t *testing.T) {
-// 		email := "test@mail.com"
-// 		id := "some-id"
-// 		exp := time.Now().Add(time.Second * 5)
-// 		token, err := GenerateVerifyEmailToken(email, id, exp)
-// 		assert.Nil(t, err)
-// 		claims, err := VerifyEmailToken(token)
-// 		assert.Nil(t, err)
-// 		assert.Equal(t, claims.Email, email)
-// 		assert.Equal(t, claims.ID, id)
-// 		assert.Equal(t, claims.ExpiresAt.Unix(), exp.Unix())
-// 	})
-//
-// 	t.Run("deny expired verify email token", func(t *testing.T) {
-// 		email := "test@mail.com"
-// 		id := "some-id"
-// 		exp := time.Now().Add(-1 * 5 * time.Second)
-// 		token, err := GenerateVerifyEmailToken(email, id, exp)
-// 		assert.Nil(t, err)
-// 		_, err = VerifyEmailToken(token)
-// 		assert.NotNil(t, err)
-// 	})
-// }
+import (
+	"os"
+	"testing"
+	"time"
+
+	"KonferCA/SPUR/db"
+	"KonferCA/SPUR/internal/jwt"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestJWT(t *testing.T) {
+	// setup env
+	os.Setenv("JWT_SECRET", "secret")
+	os.Setenv("JWT_SECRET_VERIFY_EMAIL", "test-secret")
+
+	userID := "some-user-id"
+	role := db.UserRole("user")
+	salt := []byte("test-salt")
+
+	t.Run("token salt invalidation", func(t *testing.T) {
+		// Generate initial salt
+		initialSalt := []byte("initial-salt")
+
+		// Generate tokens with initial salt
+		accessToken, refreshToken, err := jwt.GenerateWithSalt(userID, role, initialSalt)
+		assert.Nil(t, err)
+		assert.NotEmpty(t, accessToken)
+		assert.NotEmpty(t, refreshToken)
+
+		// Verify tokens work with initial salt
+		claims, err := jwt.VerifyTokenWithSalt(accessToken, initialSalt)
+		assert.Nil(t, err)
+		assert.Equal(t, claims.UserID, userID)
+		assert.Equal(t, claims.Role, role)
+		assert.Equal(t, claims.TokenType, jwt.ACCESS_TOKEN_TYPE)
+
+		// Change salt (simulating token invalidation)
+		newSalt := []byte("new-salt")
+
+		// Old tokens should fail verification with new salt
+		_, err = jwt.VerifyTokenWithSalt(accessToken, newSalt)
+		assert.NotNil(t, err, "Token should be invalid with new salt")
+
+		// Generate new tokens with new salt
+		newAccessToken, newRefreshToken, err := jwt.GenerateWithSalt(userID, role, newSalt)
+		assert.Nil(t, err)
+		assert.NotEmpty(t, newAccessToken)
+		assert.NotEmpty(t, newRefreshToken)
+
+		// New tokens should work with new salt
+		claims, err = jwt.VerifyTokenWithSalt(newAccessToken, newSalt)
+		assert.Nil(t, err)
+		assert.Equal(t, claims.UserID, userID)
+	})
+
+	t.Run("two-step verification", func(t *testing.T) {
+		salt := []byte("test-salt")
+
+		// Generate a token
+		accessToken, _, err := jwt.GenerateWithSalt(userID, role, salt)
+		assert.Nil(t, err)
+
+		// Step 1: Parse claims without verification
+		unverifiedClaims, err := jwt.ParseUnverifiedClaims(accessToken)
+		assert.Nil(t, err)
+		assert.Equal(t, userID, unverifiedClaims.UserID)
+
+		// Step 2: Verify with salt
+		verifiedClaims, err := jwt.VerifyTokenWithSalt(accessToken, salt)
+		assert.Nil(t, err)
+		assert.Equal(t, userID, verifiedClaims.UserID)
+
+		// Try to verify with wrong salt
+		wrongSalt := []byte("wrong-salt")
+		_, err = jwt.VerifyTokenWithSalt(accessToken, wrongSalt)
+		assert.NotNil(t, err, "Token should be invalid with wrong salt")
+	})
+
+	t.Run("generate access token", func(t *testing.T) {
+		accessToken, _, err := jwt.GenerateWithSalt(userID, role, salt)
+		assert.Nil(t, err)
+		assert.NotEmpty(t, accessToken)
+		claims, err := jwt.VerifyTokenWithSalt(accessToken, salt)
+		assert.Nil(t, err)
+		assert.Equal(t, claims.UserID, userID)
+		assert.Equal(t, claims.Role, role)
+		assert.Equal(t, claims.TokenType, jwt.ACCESS_TOKEN_TYPE)
+	})
+
+	t.Run("generate refresh token", func(t *testing.T) {
+		_, refreshToken, err := jwt.GenerateWithSalt(userID, role, salt)
+		assert.Nil(t, err)
+		assert.NotEmpty(t, refreshToken)
+		claims, err := jwt.VerifyTokenWithSalt(refreshToken, salt)
+		assert.Nil(t, err)
+		assert.Equal(t, claims.UserID, userID)
+		assert.Equal(t, claims.Role, role)
+		assert.Equal(t, claims.TokenType, jwt.REFRESH_TOKEN_TYPE)
+	})
+
+	t.Run("verify email token", func(t *testing.T) {
+		email := "test@mail.com"
+		id := "some-id"
+		exp := time.Now().Add(time.Second * 5)
+		token, err := jwt.GenerateVerifyEmailToken(email, id, exp)
+		assert.Nil(t, err)
+		claims, err := jwt.VerifyEmailToken(token)
+		assert.Nil(t, err)
+		assert.Equal(t, claims.Email, email)
+		assert.Equal(t, claims.ID, id)
+		assert.Equal(t, claims.ExpiresAt.Unix(), exp.Unix())
+	})
+
+	t.Run("deny expired verify email token", func(t *testing.T) {
+		email := "test@mail.com"
+		id := "some-id"
+		exp := time.Now().Add(-1 * 5 * time.Second)
+		token, err := jwt.GenerateVerifyEmailToken(email, id, exp)
+		assert.Nil(t, err)
+		_, err = jwt.VerifyEmailToken(token)
+		assert.NotNil(t, err)
+	})
+}

--- a/backend/internal/tests/rate_limit_test.go
+++ b/backend/internal/tests/rate_limit_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"KonferCA/SPUR/internal/middleware"
+	"KonferCA/SPUR/internal/v1/v1_common"
 
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
@@ -69,7 +70,7 @@ func TestRateLimiter(t *testing.T) {
 		rec = httptest.NewRecorder()
 		c = e.NewContext(req, rec)
 		err = h(c)
-		he, ok := err.(*echo.HTTPError)
+		he, ok := err.(*v1_common.APIError)
 		assert.True(t, ok)
 		assert.Equal(t, http.StatusTooManyRequests, he.Code)
 	})
@@ -103,7 +104,7 @@ func TestRateLimiter(t *testing.T) {
 			rec = httptest.NewRecorder()
 			c = e.NewContext(req, rec)
 			err = h(c)
-			he, ok := err.(*echo.HTTPError)
+			he, ok := err.(*v1_common.APIError)
 			assert.True(t, ok)
 			assert.Equal(t, http.StatusTooManyRequests, he.Code)
 		}
@@ -137,7 +138,7 @@ func TestRateLimiter(t *testing.T) {
 		c = e.NewContext(req, rec)
 		err = h(c)
 		assert.Error(t, err)
-		he, ok := err.(*echo.HTTPError)
+		he, ok := err.(*v1_common.APIError)
 		assert.True(t, ok)
 		assert.Equal(t, http.StatusTooManyRequests, he.Code)
 
@@ -179,7 +180,7 @@ func TestRateLimiter(t *testing.T) {
 			c = e.NewContext(req, rec)
 			err = h(c)
 			assert.Error(t, err)
-			he, ok := err.(*echo.HTTPError)
+			he, ok := err.(*v1_common.APIError)
 			assert.True(t, ok)
 			assert.Equal(t, http.StatusTooManyRequests, he.Code)
 

--- a/backend/internal/tests/request_validator_test.go
+++ b/backend/internal/tests/request_validator_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"KonferCA/SPUR/internal/middleware"
+	"KonferCA/SPUR/internal/v1/v1_common"
 	"os"
 	"testing"
 
@@ -169,7 +170,7 @@ func TestValidatorMiddleware(t *testing.T) {
 			err := e.Validator.Validate(tc.input)
 			if tc.expectedError {
 				assert.Error(t, err)
-				httpErr, ok := err.(*echo.HTTPError)
+				httpErr, ok := err.(*v1_common.APIError)
 				assert.True(t, ok)
 				assert.Contains(t, httpErr.Message, tc.errorMessage)
 			} else {


### PR DESCRIPTION
## Description
Updated middlewares to use APIError. As of now, I think that is everything that can return errors in the server.

## Linked Issues
- Fixes #290 

## Testing
- Updated all middleware testing files

## Checklist
Before opening this PR, make sure the PR:
- [x] Has an **assignee or group of assignees**.
- [x] Has a **reviewer or a group of reviewers**.
- [x] Is **labelled properly**.
- [x] Has the **SPUR project assigned to it**.
- [x] Has an **assigned milestone**.

Additionally, make sure that:
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.