### PR TITLE
Add Cloudflare IP support to rate limit middleware

### DIFF
--- a/backend/internal/middleware/rate_limit.go
+++ b/backend/internal/middleware/rate_limit.go
@@ -86,7 +86,11 @@ Example (auth):
 func (rl *RateLimiter) RateLimit() echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
-			ip := c.RealIP()
+			ip := c.Request().Header.Get("CF-Connecting-IP")
+			if ip == "" {
+				return echo.NewHTTPError(http.StatusForbidden, "missing client IP")
+			}
+
 			now := time.Now()
 
 			rl.mu.Lock()

--- a/backend/internal/middleware/rate_limit.go
+++ b/backend/internal/middleware/rate_limit.go
@@ -2,19 +2,15 @@ package middleware
 
 import (
 	"net/http"
-	"strings"
 	"sync"
 	"time"
-	"net"
-	"fmt"
-	"io"
 
 	"github.com/labstack/echo/v4"
 	"github.com/rs/zerolog/log"
 )
 
 /*
-visitor tracks the request statistics for a single IP address. 
+visitor tracks the request statistics for a single IP address.
 */
 type visitor struct {
 	lastSeen    time.Time
@@ -70,114 +66,6 @@ func NewRateLimiter(config *RateLimiterConfig) *RateLimiter {
 }
 
 /*
-getClientIP attempts to get the real client IP, only trusting Cloudflare headers
-when the request is verified to come from Cloudflare.
-*/
-func getClientIP(c echo.Context) string {
-	// check if request is from cloudflare by verifying CF-Connecting-IP exists
-	// AND the request is from a Cloudflare IP range
-	if cfIP := c.Request().Header.Get("CF-Connecting-IP"); cfIP != "" && isCloudflareIP(c.RealIP()) {
-		return cfIP
-	}
-
-	// if not from cloudflare, only trust the direct remote address
-	return c.RealIP()
-}
-
-var (
-	parsedCloudflareRanges []*net.IPNet
-	ipRangesMutex         sync.RWMutex
-)
-
-const (
-	cfIPv4Endpoint = "https://www.cloudflare.com/ips-v4"
-	cfIPv6Endpoint = "https://www.cloudflare.com/ips-v6"
-	// refresh every 24 hours
-	cfIPRefreshInterval = 24 * time.Hour
-)
-
-func init() {
-	// Initial load of IP ranges
-	if err := refreshCloudflareIPRanges(); err != nil {
-		log.Error().Err(err).Msg("failed to load initial Cloudflare IP ranges")
-	}
-
-	// Start background refresh
-	go func() {
-		ticker := time.NewTicker(cfIPRefreshInterval)
-		defer ticker.Stop()
-
-		for range ticker.C {
-			if err := refreshCloudflareIPRanges(); err != nil {
-				log.Error().Err(err).Msg("failed to refresh Cloudflare IP ranges")
-			}
-		}
-	}()
-}
-
-func refreshCloudflareIPRanges() error {
-	// Fetch both IPv4 and IPv6 ranges
-	ranges := make([]string, 0)
-	
-	for _, endpoint := range []string{cfIPv4Endpoint, cfIPv6Endpoint} {
-		resp, err := http.Get(endpoint)
-		if err != nil {
-			return fmt.Errorf("failed to fetch Cloudflare IPs from %s: %w", endpoint, err)
-		}
-		defer resp.Body.Close()
-
-		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return fmt.Errorf("failed to read response body: %w", err)
-		}
-
-		// Split response into lines
-		cidrs := strings.Split(string(body), "\n")
-		for _, cidr := range cidrs {
-			if cidr = strings.TrimSpace(cidr); cidr != "" {
-				ranges = append(ranges, cidr)
-			}
-		}
-	}
-
-	// Parse the new ranges
-	newRanges := make([]*net.IPNet, 0, len(ranges))
-	for _, cidr := range ranges {
-		_, ipnet, err := net.ParseCIDR(cidr)
-		if err != nil {
-			log.Error().Err(err).Str("cidr", cidr).Msg("failed to parse Cloudflare IP range")
-			continue
-		}
-		newRanges = append(newRanges, ipnet)
-	}
-
-	// Update the global ranges atomically
-	ipRangesMutex.Lock()
-	parsedCloudflareRanges = newRanges
-	ipRangesMutex.Unlock()
-
-	log.Info().Int("count", len(newRanges)).Msg("refreshed Cloudflare IP ranges")
-	return nil
-}
-
-func isCloudflareIP(ipStr string) bool {
-	ip := net.ParseIP(ipStr)
-	if ip == nil {
-		return false
-	}
-
-	ipRangesMutex.RLock()
-	defer ipRangesMutex.RUnlock()
-
-	for _, ipRange := range parsedCloudflareRanges {
-		if ipRange.Contains(ip) {
-			return true
-		}
-	}
-	return false
-}
-
-/*
 RateLimit creates a middleware function that can be applied to specific routes.
 It implements rate limiting based on client IP addresses.
 
@@ -198,7 +86,7 @@ Example (auth):
 func (rl *RateLimiter) RateLimit() echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
-			ip := getClientIP(c)
+			ip := c.RealIP()
 			now := time.Now()
 
 			rl.mu.Lock()

--- a/backend/internal/tests/rate_limit_test.go
+++ b/backend/internal/tests/rate_limit_test.go
@@ -16,7 +16,6 @@ func TestRateLimiter(t *testing.T) {
 	t.Run("allows requests within limit", func(t *testing.T) {
 		e := echo.New()
 		req := httptest.NewRequest(http.MethodGet, "/test", nil)
-		req.Header.Set("CF-Connecting-IP", "192.168.1.100")
 
 		limiter := middleware.NewRateLimiter(&middleware.RateLimiterConfig{
 			Requests:    2,

--- a/backend/internal/tests/rate_limit_test.go
+++ b/backend/internal/tests/rate_limit_test.go
@@ -13,11 +13,9 @@ import (
 )
 
 func TestRateLimiter(t *testing.T) {
-	t.Run("allows requests within limit from Cloudflare", func(t *testing.T) {
+	t.Run("allows requests within limit", func(t *testing.T) {
 		e := echo.New()
 		req := httptest.NewRequest(http.MethodGet, "/test", nil)
-		req.RemoteAddr = "173.245.48.1:1234"
-		req.Header.Set("CF-Connecting-IP", "10.0.0.1")
 
 		limiter := middleware.NewRateLimiter(&middleware.RateLimiterConfig{
 			Requests:    2,
@@ -45,11 +43,10 @@ func TestRateLimiter(t *testing.T) {
 		assert.Equal(t, http.StatusOK, rec.Code)
 	})
 
-	t.Run("blocks requests over limit from Cloudflare", func(t *testing.T) {
+	t.Run("blocks requests over limit", func(t *testing.T) {
 		e := echo.New()
 		req := httptest.NewRequest(http.MethodGet, "/test", nil)
-		req.RemoteAddr = "173.245.48.1:1234"
-		req.Header.Set("CF-Connecting-IP", "10.0.0.2")
+		req.Header.Set("X-Real-IP", "192.168.1.100")
 
 		limiter := middleware.NewRateLimiter(&middleware.RateLimiterConfig{
 			Requests:    1,
@@ -68,40 +65,6 @@ func TestRateLimiter(t *testing.T) {
 		c := e.NewContext(req, rec)
 		err := h(c)
 		assert.NoError(t, err)
-
-		rec = httptest.NewRecorder()
-		c = e.NewContext(req, rec)
-		err = h(c)
-		he, ok := err.(*echo.HTTPError)
-		assert.True(t, ok)
-		assert.Equal(t, http.StatusTooManyRequests, he.Code)
-	})
-
-	t.Run("handles direct connections correctly", func(t *testing.T) {
-		e := echo.New()
-		req := httptest.NewRequest(http.MethodGet, "/test", nil)
-		req.RemoteAddr = "192.168.1.1:1234"
-		req.Header.Set("CF-Connecting-IP", "10.0.0.3")
-		req.Header.Set("X-Real-IP", "10.0.0.3")
-
-		limiter := middleware.NewRateLimiter(&middleware.RateLimiterConfig{
-			Requests:    1,
-			Window:      100 * time.Millisecond,
-			BlockPeriod: 200 * time.Millisecond,
-			MaxBlocks:   2,
-		})
-
-		handler := func(c echo.Context) error {
-			return c.String(http.StatusOK, "OK")
-		}
-
-		h := limiter.RateLimit()(handler)
-
-		rec := httptest.NewRecorder()
-		c := e.NewContext(req, rec)
-		err := h(c)
-		assert.NoError(t, err)
-		assert.Equal(t, http.StatusOK, rec.Code)
 
 		rec = httptest.NewRecorder()
 		c = e.NewContext(req, rec)

--- a/backend/internal/tests/rate_limit_test.go
+++ b/backend/internal/tests/rate_limit_test.go
@@ -13,9 +13,11 @@ import (
 )
 
 func TestRateLimiter(t *testing.T) {
-	t.Run("allows requests within limit", func(t *testing.T) {
+	t.Run("allows requests within limit from Cloudflare", func(t *testing.T) {
 		e := echo.New()
 		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.RemoteAddr = "173.245.48.1:1234"
+		req.Header.Set("CF-Connecting-IP", "10.0.0.1")
 
 		limiter := middleware.NewRateLimiter(&middleware.RateLimiterConfig{
 			Requests:    2,
@@ -43,10 +45,11 @@ func TestRateLimiter(t *testing.T) {
 		assert.Equal(t, http.StatusOK, rec.Code)
 	})
 
-	t.Run("blocks requests over limit", func(t *testing.T) {
+	t.Run("blocks requests over limit from Cloudflare", func(t *testing.T) {
 		e := echo.New()
 		req := httptest.NewRequest(http.MethodGet, "/test", nil)
-		req.Header.Set("X-Real-IP", "192.168.1.100")
+		req.RemoteAddr = "173.245.48.1:1234"
+		req.Header.Set("CF-Connecting-IP", "10.0.0.2")
 
 		limiter := middleware.NewRateLimiter(&middleware.RateLimiterConfig{
 			Requests:    1,
@@ -65,6 +68,40 @@ func TestRateLimiter(t *testing.T) {
 		c := e.NewContext(req, rec)
 		err := h(c)
 		assert.NoError(t, err)
+
+		rec = httptest.NewRecorder()
+		c = e.NewContext(req, rec)
+		err = h(c)
+		he, ok := err.(*echo.HTTPError)
+		assert.True(t, ok)
+		assert.Equal(t, http.StatusTooManyRequests, he.Code)
+	})
+
+	t.Run("handles direct connections correctly", func(t *testing.T) {
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.RemoteAddr = "192.168.1.1:1234"
+		req.Header.Set("CF-Connecting-IP", "10.0.0.3")
+		req.Header.Set("X-Real-IP", "10.0.0.3")
+
+		limiter := middleware.NewRateLimiter(&middleware.RateLimiterConfig{
+			Requests:    1,
+			Window:      100 * time.Millisecond,
+			BlockPeriod: 200 * time.Millisecond,
+			MaxBlocks:   2,
+		})
+
+		handler := func(c echo.Context) error {
+			return c.String(http.StatusOK, "OK")
+		}
+
+		h := limiter.RateLimit()(handler)
+
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		err := h(c)
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusOK, rec.Code)
 
 		rec = httptest.NewRecorder()
 		c = e.NewContext(req, rec)

--- a/backend/internal/tests/rate_limit_test.go
+++ b/backend/internal/tests/rate_limit_test.go
@@ -16,6 +16,7 @@ func TestRateLimiter(t *testing.T) {
 	t.Run("allows requests within limit", func(t *testing.T) {
 		e := echo.New()
 		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.Header.Set("CF-Connecting-IP", "192.168.1.100")
 
 		limiter := middleware.NewRateLimiter(&middleware.RateLimiterConfig{
 			Requests:    2,
@@ -46,7 +47,7 @@ func TestRateLimiter(t *testing.T) {
 	t.Run("blocks requests over limit", func(t *testing.T) {
 		e := echo.New()
 		req := httptest.NewRequest(http.MethodGet, "/test", nil)
-		req.Header.Set("X-Real-IP", "192.168.1.100")
+		req.Header.Set("CF-Connecting-IP", "192.168.1.100")
 
 		limiter := middleware.NewRateLimiter(&middleware.RateLimiterConfig{
 			Requests:    1,
@@ -92,7 +93,7 @@ func TestRateLimiter(t *testing.T) {
 		ips := []string{"192.168.1.1", "192.168.1.2"}
 		for _, ip := range ips {
 			req := httptest.NewRequest(http.MethodGet, "/test", nil)
-			req.Header.Set("X-Real-IP", ip)
+			req.Header.Set("CF-Connecting-IP", ip)
 			rec := httptest.NewRecorder()
 			c := e.NewContext(req, rec)
 
@@ -112,13 +113,13 @@ func TestRateLimiter(t *testing.T) {
 	t.Run("allows requests after window reset", func(t *testing.T) {
 		e := echo.New()
 		req := httptest.NewRequest(http.MethodGet, "/test", nil)
-		req.Header.Set("X-Real-IP", "192.168.1.200")
+		req.Header.Set("CF-Connecting-IP", "192.168.1.200")
 
 		limiter := middleware.NewRateLimiter(&middleware.RateLimiterConfig{
 			Requests:    1,
 			Window:      100 * time.Millisecond,
-			BlockPeriod: 50 * time.Millisecond,
-			MaxBlocks:   2,
+				BlockPeriod: 50 * time.Millisecond,
+				MaxBlocks:   2,
 		})
 
 		handler := func(c echo.Context) error {
@@ -153,7 +154,7 @@ func TestRateLimiter(t *testing.T) {
 	t.Run("applies progressive blocking", func(t *testing.T) {
 		e := echo.New()
 		req := httptest.NewRequest(http.MethodGet, "/test", nil)
-		req.Header.Set("X-Real-IP", "192.168.1.300")
+		req.Header.Set("CF-Connecting-IP", "192.168.1.300")
 
 		limiter := middleware.NewRateLimiter(&middleware.RateLimiterConfig{
 			Requests:    1,


### PR DESCRIPTION
## Description
Updated rate limiter to use Cloudflare's `CF-Connecting-IP` header instead of `X-Real-IP` since all traffic is routed through Cloudflare.

## Linked Issues
- Fixes #294 

## Testing
- `backend/internal/tests/rate_limit_test.go`

## Checklist
Before opening this PR, make sure the PR:
- [x] Has an **assignee or group of assignees**.
- [x] Has a **reviewer or a group of reviewers**.
- [x] Is **labelled properly**.
- [x] Has the **SPUR project assigned to it**.
- [x] Has an **assigned milestone**.

Additionally, make sure that:
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.