### PR TITLE
Fix AnchorLinks last link not mark as active if target is at end of page

### DIFF
--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -11,13 +11,16 @@ export { TextArea } from './TextArea';
 export { TeamMembers } from './TeamMembers';
 export { SocialLinks } from './SocialLinks';
 export { DateInput } from './DateInput';
-export { 
-  PageLayout, 
-  Section, 
-  Grid, 
-  Footer, 
-  Header, 
-  DashboardTemplate,
-  AdminDashboard,
-  UserDashboard
+export {
+    PageLayout,
+    Section,
+    Grid,
+    Footer,
+    Header,
+    DashboardTemplate,
+    AdminDashboard,
+    UserDashboard,
 } from './layout';
+
+import type { AnchorLinkItem } from './AnchorLinks';
+export type { AnchorLinkItem };

--- a/frontend/src/components/tests/AnchorLinks.test.tsx
+++ b/frontend/src/components/tests/AnchorLinks.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { AnchorLinks } from '@components';
+import type { AnchorLinkItem } from '@components';
+
+describe('AnchorLinks', () => {
+    const links: AnchorLinkItem[] = [
+        {
+            label: 'one',
+            target: '#one',
+        },
+        {
+            label: 'two',
+            target: '#two',
+            offset: 10,
+        },
+    ];
+
+    it('should render all provided links', () => {
+        render(<AnchorLinks links={links} />);
+        const found = screen.getAllByRole('listitem');
+        expect(found).toHaveLength(links.length);
+        found.forEach((link, i) => {
+            expect(link.textContent).toEqual(links[i].label);
+        });
+    });
+
+    it('should render all provided links using rendering function', () => {
+        render(
+            <AnchorLinks links={links}>
+                {(link) => <button>{link.label}</button>}
+            </AnchorLinks>
+        );
+        links.forEach((link) => {
+            expect(() =>
+                screen.getByRole('button', { name: link.label })
+            ).not.toThrow();
+        });
+    });
+});

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -5,6 +5,7 @@ export {
     scrollTo,
     scrollToTop,
     isElementInView,
+    isAtEndOfPage,
 } from './scroll';
 
 export { getApiUrl, HttpStatusCode } from './api';

--- a/frontend/src/utils/scroll.ts
+++ b/frontend/src/utils/scroll.ts
@@ -39,3 +39,14 @@ export function isElementInView(el: Element | null): boolean {
 
     return isNotCompletelyOutOfView;
 }
+
+/*
+ * Checks whether the current scroll position is at the bottom of the page.
+ */
+export function isAtEndOfPage(): boolean {
+    const totalHeight = document.documentElement.offsetHeight;
+    // Must round scrollY because it gives an small inaccurate decimal answer.
+    const scrollPostition = window.innerHeight + Math.round(window.scrollY);
+    console.log(totalHeight, scrollPostition);
+    return scrollPostition >= totalHeight;
+}


### PR DESCRIPTION
## Description
This PR fixes the issue where the last link is never marked as active if the target element is right at the end of the page. The abnormal behaviour was that the second to last link is always the one marked as active because the AnchorLinks component chooses the closest one to the top when multiple targets are in view.

## Linked Issues
- Fixes #161 

## Testing
- Add new AnchorLinks component test `components/test/AnchorLinks.test.tsx`
- The test only test for the existence of the links but not able to test scroll since `jsDom` does not implement layouts.

## Checklist
Before opening this PR, make sure the PR:
- [x] Has an **assignee or group of assignees**.
- [x] Has a **reviewer or a group of reviewers**.
- [x] Is **labelled properly**.
- [x] Has the **SPUR project assigned to it**.
- [x] Has an **assigned milestone**.

Additionally, make sure that:
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.