### PR TITLE
Add project form questions

### DIFF
--- a/backend/.sqlc/migrations/20241215194302_initial_schema.sql
+++ b/backend/.sqlc/migrations/20241215194302_initial_schema.sql
@@ -75,6 +75,7 @@ CREATE TABLE project_questions (
     section varchar NOT NULL DEFAULT 'overall',
     required boolean NOT NULL DEFAULT false,
     validations varchar,
+    sub_section_order int NOT NULL, -- defines in which order the question appears in the sub-section
     created_at bigint NOT NULL DEFAULT extract(epoch from now()),
     updated_at bigint NOT NULL DEFAULT extract(epoch from now())
 ); 

--- a/backend/.sqlc/migrations/20241226195458_add_default_questions.sql
+++ b/backend/.sqlc/migrations/20241226195458_add_default_questions.sql
@@ -78,93 +78,94 @@ INSERT INTO project_questions (sub_section_order, question, section, sub_section
     (4, 'Do you have any contracts, agreements, or letters of intent you''d like to include?', 'The Basics', 'Legal and Compliance', 'textinput|file', NULL, false, 'url');
 
 -- SECTION: The Team
-INSERT INTO project_questions (sub_section_order, question, section, sub_section, input_type, required, validations) VALUES 
+INSERT INTO project_questions (sub_section_order, question, section, sub_section, input_type, options, required, validations) VALUES 
     -- SUB-SECTION: Team Members
-    (0, '', 'The Team', 'Team Members', 'team', true, ''),
+    (0, '', 'The Team', 'Team Members', 'team', NULL, true, ''),
 
     -- SUB-SECTION: Team Background
-    (0, 'Who are the founders and key team members, and what are their backgrounds?', 'The Team', 'Team Background', 'textarea', true, ''),
-    (1, 'Do they have relevant experience in the industry?', 'The Team', 'Team Background', 'textarea', true, ''),
-    (2, 'How committed are the founders (e.g., full-time, personal investment)?', 'The Team', 'Team Background', 'textarea', true, ''),
-    (3, 'Does the team have a balanced skill set (technical, operational, marketing, finance)?', 'The Team', 'Team Background', 'textarea', true, ''),
+    (0, 'Who are the founders and key team members, and what are their backgrounds?', 'The Team', 'Team Background', 'textarea', NULL, true, ''),
+    (1, 'Do they have relevant experience in the industry?', 'The Team', 'Team Background', 'textarea', NULL, true, ''),
+    (2, 'How committed are the founders (e.g., full-time, personal investment)?', 'The Team', 'Team Background', 'textarea', NULL, true, ''),
+    (3, 'Does the team have a balanced skill set (technical, operational, marketing, finance)?', 'The Team', 'Team Background', 'textarea', NULL, true, ''),
 
     -- SUB-SECTION: Personal Background
-    (0, 'What is your professional and educational background?', 'The Team', 'Personal Background', 'textarea', true, ''),
-    (1, 'What relevant experience do you have in this industry or market?', 'The Team', 'Personal Background', 'textarea', true, ''),
-    (2, 'Have you successfully launched or managed any startups or businesses before? If so, what were the outcomes?', 'The Team', 'Personal Background', 'textarea', true, ''),
-    (3, 'What lessons did you learn from your previous ventures, both successful and unsuccessful?', 'The Team', 'Personal Background', 'textarea', true, ''),
-    (4, 'How well do you understand the technical and operational aspects of your business?', 'The Team', 'Personal Background', 'textarea', true, ''),
+    (0, 'What is your professional and educational background?', 'The Team', 'Personal Background', 'textarea', NULL, true, ''),
+    (1, 'What relevant experience do you have in this industry or market?', 'The Team', 'Personal Background', 'textarea', NULL, true, ''),
+    (2, 'Have you successfully launched or managed any startups or businesses before? If so, what were the outcomes?', 'The Team', 'Personal Background', 'textarea', NULL, true, ''),
+    (3, 'What lessons did you learn from your previous ventures, both successful and unsuccessful?', 'The Team', 'Personal Background', 'textarea', NULL, true, ''),
+    (4, 'How well do you understand the technical and operational aspects of your business?', 'The Team', 'Personal Background', 'textarea', NULL, true, ''),
 
     -- SUB-SECTION: Vision and Motivation
-    (0, 'What inspired you to start this business?', 'The Team', 'Vision and Motivation', 'textarea', true, ''),
-    (0, 'What is the long-term vision for the company, and how do you plan to achieve it?', 'The Team', 'Vision and Motivation', 'textarea', true, ''),
-    (0, 'What motivates you to continue pursuing this business, especially during challenging times?', 'The Team', 'Vision and Motivation', 'textarea', true, ''),
-    (0, 'How do you measure success for yourself and your business?', 'The Team', 'Vision and Motivation', 'textarea', true, ''),
+    (0, 'What inspired you to start this business?', 'The Team', 'Vision and Motivation', 'textarea', NULL, true, ''),
+    (1, 'What is the long-term vision for the company, and how do you plan to achieve it?', 'The Team', 'Vision and Motivation', 'textarea', NULL, true, ''),
+    (2, 'What motivates you to continue pursuing this business, especially during challenging times?', 'The Team', 'Vision and Motivation', 'textarea', NULL, true, ''),
+    (3, 'How do you measure success for yourself and your business?', 'The Team', 'Vision and Motivation', 'textarea', NULL, true, ''),
 
     -- SUB-SECTION: Leadership
-    (0, 'What is your leadership style?', 'The Team', 'Leadership', 'textarea', true, ''),
-    (0, 'How do you manage and motivate your team?', 'The Team', 'Leadership', 'textarea', true, ''),
-    (0, 'How do you handle conflict within the team and/or with external stakeholders?', 'The Team', 'Leadership', 'textarea', true, ''),
-    (0, 'Are you comfortable delegating responsibilities, or do you tend to take on too much yourself?', 'The Team', 'Leadership', 'textarea', true, ''),
-    (0, 'What processes do you have in place to attract, retain, and develop talent?', 'The Team', 'Leadership', 'textarea', true, ''),
+    (0, 'What is your leadership style?', 'The Team', 'Leadership', 'textarea', NULL, true, ''),
+    (1, 'How do you manage and motivate your team?', 'The Team', 'Leadership', 'textarea', NULL, true, ''),
+    (2, 'How do you handle conflict within the team and/or with external stakeholders?', 'The Team', 'Leadership', 'textarea', NULL, true, ''),
+    (3, 'Are you comfortable delegating responsibilities, or do you tend to take on too much yourself?', 'The Team', 'Leadership', 'textarea', NULL, true, ''),
+    (4, 'What processes do you have in place to attract, retain, and develop talent?', 'The Team', 'Leadership', 'textarea', NULL, true, ''),
 
     -- SUB-SECTION: Personal Commitment
-    (0, 'How committed are you to this venture?', 'The Team', 'Personal Commitment', 'textarea', true, ''),
-    (0, 'How much personal capital have you invested in the business?', 'The Team', 'Personal Commitment', 'textarea', true, ''),
-    (0, 'Are there any other obligations or ventures that could divide your focus?', 'The Team', 'Personal Commitment', 'textarea', true, ''),
-    (0, 'How long do you see yourself staying actively involved in the business?', 'The Team', 'Personal Commitment', 'textarea', true, ''),
+    (0, 'How committed are you to this venture?', 'The Team', 'Personal Commitment', 'textarea', NULL, true, ''),
+    (1, 'How much personal capital have you invested in the business?', 'The Team', 'Personal Commitment', 'textarea', NULL, true, ''),
+    (2, 'Are there any other obligations or ventures that could divide your focus?', 'The Team', 'Personal Commitment', 'textarea', NULL, true, ''),
+    (3, 'How long do you see yourself staying actively involved in the business?', 'The Team', 'Personal Commitment', 'textarea', NULL, true, ''),
 
     -- SUB-SECTION: Knowledge and Preparedness
-    (0, 'How well do you understand your target market, customer needs, and competitive landscape?', 'The Team', 'Knowledge and Preparedness', 'textarea', true, ''),
-    (0, 'What research or validation have you done to confirm demand for your product or service?', 'The Team', 'Knowledge and Preparedness', 'textarea', true, ''),
-    (0, 'Do you have a roadmap for the next 12 months, 3 years, and 5 years?', 'The Team', 'Knowledge and Preparedness', 'textarea', true, ''),
-    (0, 'What contingencies have you planned for potential risks or challenges?', 'The Team', 'Knowledge and Preparedness', 'textarea', true, ''),
+    (0, 'How well do you understand your target market, customer needs, and competitive landscape?', 'The Team', 'Knowledge and Preparedness', 'textarea', NULL, true, ''),
+    (1, 'What research or validation have you done to confirm demand for your product or service?', 'The Team', 'Knowledge and Preparedness', 'textarea', NULL, true, ''),
+    (2, 'Do you have a roadmap for the next 12 months, 3 years, and 5 years?', 'The Team', 'Knowledge and Preparedness', 'textarea', NULL, true, ''),
+    (3, 'What contingencies have you planned for potential risks or challenges?', 'The Team', 'Knowledge and Preparedness', 'textarea', NULL, true, ''),
 
     -- SUB-SECTION: Problem-Solving and Resillience
-    (0, 'Can you share an example of a major challenge you’ve faced and how you resolved it', 'The Team', 'Problem-Solving and Resillience', 'textarea', true, ''),
-    (0, 'How do you make decisions under pressure or with incomplete information?', 'The Team', 'Problem-Solving and Resillience', 'textarea', true, ''),
-    (0, 'What are the biggest risks to your business, and how do you plan to mitigate them', 'The Team', 'Problem-Solving and Resillience', 'textarea', true, ''),
-    (0, 'How do you handle setbacks or failures?', 'The Team', 'Problem-Solving and Resillience', 'textarea', true, ''),
-    (0, 'Relationships and Networking', 'The Team', 'Problem-Solving and Resillience', 'checkbox', true, ''),
-    (0, 'Can you share an example of a major challenge you’ve faced and how you resolved it', 'The Team', 'Problem-Solving and Resillience', 'textarea', true, ''),
-    (0, 'Can you share an example of a major challenge you’ve faced and how you resolved it', 'The Team', 'Problem-Solving and Resillience', 'textarea', true, ''),
-    (0, 'Can you share an example of a major challenge you’ve faced and how you resolved it', 'The Team', 'Problem-Solving and Resillience', 'textarea', true, ''),
+    (0, 'Can you share an example of a major challenge you’ve faced and how you resolved it', 'The Team', 'Problem-Solving and Resillience', 'textarea', NULL, true, ''),
+    (1, 'How do you make decisions under pressure or with incomplete information?', 'The Team', 'Problem-Solving and Resillience', 'textarea', NULL, true, ''),
+    (2, 'What are the biggest risks to your business, and how do you plan to mitigate them', 'The Team', 'Problem-Solving and Resillience', 'textarea', NULL, true, ''),
+    (3, 'How do you handle setbacks or failures?', 'The Team', 'Problem-Solving and Resillience', 'textarea', NULL, true, ''),
 
     -- SUB-SECTION: Relationships and Networking
-    (0, 'What key partnerships, relationships, or networks have you built to support your business?', 'The Team', 'Relationships and Networking', 'textarea', true, ''),
-    (0, 'How do you approach building relationships with customers, suppliers, and investors?', 'The Team', 'Relationships and Networking', 'textarea', true, ''),
-    (0, 'Are you active in relevant industry communities or events?', 'The Team', 'Relationships and Networking', 'textarea', true, ''),
+    (0, 'What key partnerships, relationships, or networks have you built to support your business?', 'The Team', 'Relationships and Networking', 'textarea', NULL, true, ''),
+    (1, 'How do you approach building relationships with customers, suppliers, and investors?', 'The Team', 'Relationships and Networking', 'textarea', NULL, true, ''),
+    (2, 'Are you active in relevant industry communities or events?', 'The Team', 'Relationships and Networking', 'textarea', NULL, true, ''),
 
     -- SUB-SECTION: Personality and Soft Skills
-    (0, 'How would your team describe your management style and personality?', 'The Team', 'Personality and Soft Skilss', 'textarea', true, ''),
-    (0, 'How do you handle feedback or criticism?', 'The Team', 'Personality and Soft Skilss', 'textarea', true, ''),
-    (0, 'What are your leadership strengths, and what areas are you actively working to improve?', 'The Team', 'Personality and Soft Skilss', 'textarea', true, ''),
-    (0, 'How do you maintain your focus and energy while balancing the demands of entrepreneurship?', 'The Team', 'Personality and Soft Skilss', 'textarea', true, '');
+    (0, 'How would your team describe your management style and personality?', 'The Team', 'Personality and Soft Skilss', 'textarea', NULL, true, ''),
+    (1, 'How do you handle feedback or criticism?', 'The Team', 'Personality and Soft Skilss', 'textarea', NULL, true, ''),
+    (2, 'What are your leadership strengths, and what areas are you actively working to improve?', 'The Team', 'Personality and Soft Skilss', 'textarea', NULL, true, ''),
+    (3, 'How do you maintain your focus and energy while balancing the demands of entrepreneurship?', 'The Team', 'Personality and Soft Skilss', 'textarea', NULL, true, '');
 
 -- SECTION: The History nothing in notion yet
 -- INSERT INTO project_questions (question, section, sub_section, input_type, required, validations) VALUES
 
 -- SECTION: The Financials
-INSERT INTO project_questions (sub_section_order, question, section, sub_section, input_type, required, validations) VALUES
+INSERT INTO project_questions (sub_section_order, question, section, sub_section, input_type, options, required, validations) VALUES
     -- SUB-SECTION: Financial and Strategic Understanding
-    (0, 'Do you clearly understand your financial metrics (e.g., revenue, expenses, cash flow)?', 'The Financials', 'Financial and Strategic Understanding', 'textarea', true, ''),
-    (0, 'What is your business scaling strategy, and how will you fund growth?', 'The Financials', 'Financial and Strategic Understanding', 'textarea', true, ''),
-    (0, 'How do you prioritize spending and allocate resources?', 'The Financials', 'Financial and Strategic Understanding', 'textarea', true, ''),
-    (0, 'What is your exit strategy, and how does it align with investor expectations?', 'The Financials', 'Financial and Strategic Understanding', 'textarea', true, ''),
+    (0, 'Do you clearly understand your financial metrics (e.g., revenue, expenses, cash flow)?', 'The Financials', 'Financial and Strategic Understanding', 'textarea', NULL, true, ''),
+    (1, 'What is your business scaling strategy, and how will you fund growth?', 'The Financials', 'Financial and Strategic Understanding', 'textarea', NULL, true, ''),
+    (2, 'How do you prioritize spending and allocate resources?', 'The Financials', 'Financial and Strategic Understanding', 'textarea', NULL, true, ''),
+    (3, 'What is your exit strategy, and how does it align with investor expectations?', 'The Financials', 'Financial and Strategic Understanding', 'textarea', NULL, true, ''),
 
     -- SUB-SECTION: Financial Overview
-    (0, 'What is the current revenue and growth rate?', 'The Financials', 'Financial Overview', 'textarea', true, ''),
-    (0, 'What are the gross and net profit margins?', 'The Financials', 'Financial Overview', 'textarea', true, ''),
-    (0, 'What is the customer acquisition cost (CAC) and lifetime value (LTV)?', 'The Financials', 'Financial Overview', 'textarea', true, ''),
-    (0, 'Are the financial projections realistic and based on credible assumptions?', 'The Financials', 'Financial Overview', 'textarea', true, ''),
-    (0, 'What is the current burn rate, and how much runway is left?', 'The Financials', 'Financial Overview', 'textarea', true, ''),
+    (0, 'What is the current revenue and growth rate?', 'The Financials', 'Financial Overview', 'textarea', NULL, true, ''),
+    (1, 'What are the gross and net profit margins?', 'The Financials', 'Financial Overview', 'textarea', NULL, true, ''),
+    (2, 'What is the customer acquisition cost (CAC) and lifetime value (LTV)?', 'The Financials', 'Financial Overview', 'textarea', NULL, true, ''),
+    (3, 'Are the financial projections realistic and based on credible assumptions?', 'The Financials', 'Financial Overview', 'textarea', NULL, true, ''),
+    (4, 'What is the current burn rate, and how much runway is left?', 'The Financials', 'Financial Overview', 'textarea', NULL, true, ''),
 
     -- SUB-SECTION: Financial Needs & Usage
-    (0, 'How much funding is the startup seeking, and what will it be used for?', 'The Financials', 'Financial Needs & Usage', 'textarea', true, ''),
-    (0, 'What milestones will the funding help achieve?', 'The Financials', 'Financial Needs & Usage', 'textarea', true, ''),
-    (0, 'Are there other sources of funding (e.g., grants, loans, existing investors)?', 'The Financials', 'Financial Needs & Usage', 'textarea', true, ''),
-    (0, 'What is the proposed valuation, and is it justified?', 'The Financials', 'Financial Needs & Usage', 'textarea', true, '');
+    (0, 'How much funding is the startup seeking, and what will it be used for?', 'The Financials', 'Financial Needs & Usage', 'textarea', NULL, true, ''),
+    (1, 'What milestones will the funding help achieve?', 'The Financials', 'Financial Needs & Usage', 'textarea', NULL, true, ''),
+    (2, 'Are there other sources of funding (e.g., grants, loans, existing investors)?', 'The Financials', 'Financial Needs & Usage', 'textarea', NULL, true, ''),
+    (3, 'What is the proposed valuation, and is it justified?', 'The Financials', 'Financial Needs & Usage', 'textarea', NULL, true, ''),
 
+    -- SUB-SECTION: Documents
+    (0, 'Cap table', 'The Financials', 'Documents', 'file', NULL, true, ''),
+    (1, 'Income statement', 'The Financials', 'Documents', 'file', NULL, true, ''),
+    (2, 'Balance sheet', 'The Financials', 'Documents', 'file', NULL, true, ''),
+    (3, 'Cash flow', 'The Financials', 'Documents', 'file', NULL, true, '');
 
 -- +goose StatementEnd
 

--- a/backend/.sqlc/migrations/20241226195458_add_default_questions.sql
+++ b/backend/.sqlc/migrations/20241226195458_add_default_questions.sql
@@ -1,10 +1,5 @@
 -- +goose Up
 -- +goose StatementBegin
--- alter project questions table to include a sub-section column
--- sub-section helps organize questions into smaller groups (how they are grouped in UI/UX)
-ALTER TABLE IF EXISTS project_questions
-ADD COLUMN sub_section VARCHAR(255) NOT NULL;
-
 -- enum type for different input types
 CREATE TYPE input AS ENUM (
     'textinput', -- single line input
@@ -12,9 +7,16 @@ CREATE TYPE input AS ENUM (
     'select', -- single selection/dropdown input
     'checkbox', -- checkbox question with one or more choices
     'radio', -- single selection with one or more choices
+    -- team creation is a list of objects with the basic information of a team member
     'team', -- team creation input
     'file' -- file upload input
 );
+
+-- alter project questions table to include a sub-section column
+-- sub-section helps organize questions into smaller groups (how they are grouped in UI/UX)
+ALTER TABLE IF EXISTS project_questions
+ADD COLUMN sub_section VARCHAR(255) NOT NULL;
+
 -- alter project questions table to include the type of input the question is for frontend use.
 ALTER TABLE IF EXISTS project_questions
 ADD COLUMN input_type input NOT NULL;
@@ -26,65 +28,70 @@ ADD COLUMN options VARCHAR(255)[];
 -- seed database with initial default questions
 
 -- SECTION: The Basics
-INSERT INTO project_questions (question, section, sub_section, input_type, required, validations) VALUES 
-    -- SUB-SECTION: Business Overview
-    ('What is the core product or service, and what problem does it solve?', 'The Basics', 'Business Overview', 'textarea', true, ''),
-    ('What is the unique value proposition?', 'The Basics', 'Business Overview', 'textarea', true, ''),
-    ('What is the size and growth rate of the target market?', 'The Basics', 'Business Overview', 'textarea', true, ''),
-    ('Who are the main competitors, and how is the business differentiated from them?', 'The Basics', 'Business Overview', 'textarea', true, ''),
+INSERT INTO project_questions (sub_section_order, question, section, sub_section, input_type, options, required, validations) VALUES 
+    -- SUB-SECTION: Company Pitch
+    (0, 'Include a link to a 5-minute video of you or your company pitching itself.', 'The Basics', 'Company Pitch', 'textinput', NULL, false, 'url'),
+    (1, 'Please upload a pitch deck.', 'The Basics', 'Company Pitch', 'textinput|file', false, 'url'),
 
-    -- SUB-SECTION: Market Analysis
-    ('Who are the target customers, and what are their needs?', 'The Basics', 'Market Analysis', 'textarea', true, ''),
-    ('What is the total addressable market (TAM), and how much can the startup realistically capture?', 'The Basics', 'Market Analysis', 'textarea', true, ''),
-    ('What are the main market trends and drivers?', 'The Basics', 'Market Analysis', 'textarea', true, ''),
-    ('What are the main market trends and drivers?', 'The Basics', 'Market Analysis', 'textarea', true, ''),
-    ('Are there any significant barriers to entry or competitive advantages?', 'The Basics', 'Market Analysis', 'textarea', true, ''),
+    -- SUB-SECTION: Business Overview
+    (0, 'What is the core product or service, and what problem does it solve?', 'The Basics', 'Business Overview', 'textarea', NULL, true, ''),
+    (1, 'What is the unique value proposition?', 'The Basics', 'Business Overview', 'textarea', NULL, true, ''),
+    (2, 'Who are the main competitors, and how is the business differentiated from them?', 'The Basics', 'Business Overview', 'textarea', NULL, true, ''),
+    (3, "What is the company's mission?", 'The Basics', 'Business Overview', 'textinput', NULL, true, ''),
+    (4, "What is the company's business plan?", 'The Basics', 'Business Overview', 'textinput|file', NULL, true, ''),
+
+    -- SUB-SECTION: Market Analysis & Research
+    (0, 'Who are the target customers, and what are their needs?', 'The Basics', 'Market Analysis & Research', 'textarea', NULL, true, ''),
+    (1, 'What is the size and growth rate of the target market?', 'The Basics', 'Market Analysis & Research', 'textarea', NULL, true, ''),
+    (2, 'What is the total addressable market (TAM), and how much can the startup realistically capture?', 'The Basics', 'Market Analysis & Research', 'textarea', NULL, true, ''),
+    (3, 'What are the main market trends and drivers?', 'The Basics', 'Market Analysis & Research', 'textarea', NULL, false, ''),
+    (4, 'Are there any significant barriers to entry or competitive advantages?', 'The Basics', 'Market Analysis & Research', 'textarea', NULL, false, ''),
+    (5, "Do you have any market research-related documents you'd like to inlcude?", 'The Basics', 'Market Analysis & Research', 'textinput|file', NULL, false, 'url'),
+    (6, "Do you have any customer data-related documents you'd like to include?", 'The Basics', 'Market Analysis & Research', 'textinput|file', NULL, false, 'url'),
 
     -- SUB-SECTION: Product or Service
-    ('What stage of development is the product in (idea, prototype, MVP, production)?', 'The Basics', 'Product or Service', 'textarea', true, ''),
-    ('What feedback has been received from early customers or beta users?', 'The Basics', 'Product or Service', 'textarea', true, ''),
-    ('Are any intellectual property (IP) protections, such as patents or trademarks in place?', 'The Basics', 'Product or Service', 'textarea', true, ''),
-    ('How scalable is the product/service?', 'The Basics', 'Product or Service', 'textarea', true, ''),
+    (0, 'What stage of development is the product in (idea, prototype, MVP, production)?', 'The Basics', 'Product or Service', 'select', '{Idea,Prototype,MVP,Production}', true, ''),
+    (1, 'How scalable is the product/service?', 'The Basics', 'Product or Service', 'textarea', NULL, true, ''),
+    (2, 'What feedback has been received from early customers or beta users?', 'The Basics', 'Product or Service', 'textarea', NULL, false, ''),
+    (3, 'Are any intellectual property (IP) protections, such as patents or trademarks in place?', 'The Basics', 'Product or Service', 'textarea', NULL, false, ''),
 
     -- SUB-SECTION: Traction
-    ('How many customers or users does the startup currently have?', 'The Basics', 'Traction', 'textarea', true, ''),
-    ('Are there partnerships, contracts, or letters of interest in place?', 'The Basics', 'Traction', 'textarea', true, ''),
-    ('Has the startup received media coverage, awards, or endorsements?', 'The Basics', 'Traction', 'textarea', true, ''),
-    ('What milestones has the startup achieved so far?', 'The Basics', 'Traction', 'textarea', true, ''),
+    (0, 'How many customers or users does the startup currently have?', 'The Basics', 'Traction', 'textarea', NULL, true, ''),
+    (1, 'Are there partnerships in place?', 'The Basics', 'Traction', 'textarea', NULL, true, ''),
+    (2, 'Has the startup received media coverage, awards, or endorsements?', 'The Basics', 'Traction', 'textarea', NULL, true, ''),
+    (3, 'What milestones has the startup achieved so far?', 'The Basics', 'Traction', 'textarea', NULL, true, ''),
 
     -- SUB-SECTION: Risks and Challenges
-    ('What are the major risks (market, operational, competitive, regulatory)?', 'The Basics', 'Risks and Challenges', 'textarea', true, ''),
-    ('How does the startup plan to mitigate these risks?', 'The Basics', 'Risks and Challenges', 'textarea', true, ''),
-    ('Are there any pending legal or compliance issues?', 'The Basics', 'Risks and Challenges', 'textarea', true, ''),
-    ('Are there any key dependencies (e.g., suppliers, technology)?', 'The Basics', 'Risks and Challenges', 'textarea', true, ''),
+    (0, 'What are the major risks (market, operational, competitive, regulatory)?', 'The Basics', 'Risks and Challenges', 'textarea', NULL, true, ''),
+    (1, 'How does the startup plan to mitigate these risks?', 'The Basics', 'Risks and Challenges', 'textarea', NULL, true, ''),
+    (2, 'Are there any key dependencies (e.g., suppliers, technology)?', 'The Basics', 'Risks and Challenges', 'textinput', NULL, true, ''),
 
     -- SUB-SECTION: Exit Strategy
-    ('What is the long-term vision for the business?', 'The Basics', 'Exit Strategy', 'textarea', true, ''),
-    ('Does the startup have a defined exit strategy (e.g., acquisition, IPO)?', 'The Basics', 'Exit Strategy', 'textarea', true, ''),
-    ('Are there potential acquirers or exit opportunities in the market?', 'The Basics', 'Exit Strategy', 'textarea', true, ''),
-    ('What is the projected return on investment (ROI) for investors?', 'The Basics', 'Exit Strategy', 'textarea', true, ''),
+    (0, 'What is the long-term vision for the business?', 'The Basics', 'Exit Strategy', 'textarea', NULL, true, ''),
+    (1, 'Does the startup have a defined exit strategy (e.g., acquisition, IPO)?', 'The Basics', 'Exit Strategy', 'textarea', NULL, true, ''),
+    (2, 'Are there potential acquirers or exit opportunities in the market?', 'The Basics', 'Exit Strategy', 'textinput', NULL, false, ''),
+    (3, 'What is the projected return on investment (ROI) for investors?', 'The Basics', 'Exit Strategy', 'textarea', NULL, false, ''),
 
     -- SUB-SECTION: Alignment and Impact
-    ('Does the startup align with SPUR’s values and mission?', 'The Basics', 'Alignment and Impact', 'textarea', true, ''),
-    ('What is the potential for a positive impact?', 'The Basics', 'Alignment and Impact', 'textarea', true, ''),
-    ('What is their mission?', 'The Basics', 'Alignment and Impact', 'textarea', true, ''),
-    ('How does the startup contribute to local or global communities?', 'The Basics', 'Alignment and Impact', 'textarea', true, ''),
+    (0, 'Does the startup align with SPUR’s values and mission?', 'The Basics', 'Alignment and Impact', 'textarea', NULL, true, ''),
+    (1, "How does the startup align with SPUR's strategic priorities and goals?", 'The Basics', 'Alignment and Impact', 'textarea', NULL, true, ''),
+    (2, "Are there potential synergies with other startups or partners from SPUR?", 'The Basics', 'Alignment and Impact', 'textarea', NULL, true, ''),
+    (3, "Can SPUR provide unique value beyond funding (e.g., mentorship, networking)?", 'The Basics', 'Alignment and Impact', 'textarea', NULL, true, ''),
+    (4, "Are you open to mentorship, guidance or collaboration from SPUR or its network?", 'The Basics', 'Alignment and Impact', 'textarea', NULL, true, ''),
+    (5, 'What is the potential for a positive impact?', 'The Basics', 'Alignment and Impact', 'textarea', NULL, true, ''),
+    (6, 'How does the startup contribute to local or global communities?', 'The Basics', 'Alignment and Impact', 'textarea', NULL, true, ''),
 
     -- SUB-SECTION: Legal and Compliance
-    ('Is the company properly registered and in good legal standing?', 'The Basics', 'Legal and Compliance', 'textarea', true, ''),
-    ('Are the ownership and equity structures clear and documented?', 'The Basics', 'Legal and Compliance', 'textarea', true, ''),
-    ('Are there any outstanding legal disputes or liabilities?', 'The Basics', 'Legal and Compliance', 'textarea', true, ''),
-    ('Does the company comply with industry-specific regulations?', 'The Basics', 'Legal and Compliance', 'textarea', true, ''),
-
-    -- SUB-SECTION: Strategic Fit with SPUR
-    ('How does the startup align with SPUR’s strategic priorities and goals?', 'The Basics', 'Strategic Fit with SPUR', 'textarea', true, ''),
-    ('Are there potential synergies with other startups or partners from SPUR?', 'The Basics', 'Strategic Fit with SPUR', 'textarea', true, ''),
-    ('Can SPUR provide unique value beyond funding (e.g., mentorship, networking)?', 'The Basics', 'Strategic Fit with SPUR', 'textarea', true, '');
+    (0, 'Is the company properly registered and in good legal standing?', 'The Basics', 'Legal and Compliance', 'textinput', NULL, true, ''),
+    (1, 'Are the ownership and equity structures clear and documented?', 'The Basics', 'Legal and Compliance', 'textinput', NULL, true, ''),
+    (2, 'Are there any outstanding legal disputes or liabilities?', 'The Basics', 'Legal and Compliance', 'textinput', NULL, true, ''),
+    (3, 'Does the company comply with industry-specific regulations?', 'The Basics', 'Legal and Compliance', 'textinput', NULL, true, ''),
+    (4, "Do you have any contracts, agreements, or letters of intent you'd like to include?", 'The Basics', 'Legal and Compliance', 'textinput|file', NULL, false, 'url'),
 
 -- SECTION: The Team
 INSERT INTO project_questions (question, section, sub_section, input_type, required, validations) VALUES 
     -- SUB-SECTION: Team Members
-    ('', 'The Team', 'Team Members', 'team', false, ''),
+    ('', 'The Team', 'Team Members', 'team', true, ''),
 
     -- SUB-SECTION: Team Background
     ('Who are the founders and key team members, and what are their backgrounds?', 'The Team', 'Team Background', 'textarea', true, ''),
@@ -132,20 +139,58 @@ INSERT INTO project_questions (question, section, sub_section, input_type, requi
     ('Relationships and Networking', 'The Team', 'Problem-Solving and Resillience', 'checkbox', true, ''),
     ('Can you share an example of a major challenge you’ve faced and how you resolved it', 'The Team', 'Problem-Solving and Resillience', 'textarea', true, ''),
     ('Can you share an example of a major challenge you’ve faced and how you resolved it', 'The Team', 'Problem-Solving and Resillience', 'textarea', true, ''),
-    ('Can you share an example of a major challenge you’ve faced and how you resolved it', 'The Team', 'Problem-Solving and Resillience', 'textarea', true, '');
+    ('Can you share an example of a major challenge you’ve faced and how you resolved it', 'The Team', 'Problem-Solving and Resillience', 'textarea', true, ''),
 
--- TODO: add remaining questions for problem solving
--- TODO: design new schema that can represent the different types of inputs for each question.
+    -- SUB-SECTION: Relationships and Networking
+    ('What key partnerships, relationships, or networks have you built to support your business?', 'The Team', 'Relationships and Networking', 'textarea', true, ''),
+    ('How do you approach building relationships with customers, suppliers, and investors?', 'The Team', 'Relationships and Networking', 'textarea', true, ''),
+    ('Are you active in relevant industry communities or events?', 'The Team', 'Relationships and Networking', 'textarea', true, ''),
+
+    -- SUB-SECTION: Personality and Soft Skills
+    ('How would your team describe your management style and personality?', 'The Team', 'Personality and Soft Skilss', 'textarea', true, ''),
+    ('How do you handle feedback or criticism?', 'The Team', 'Personality and Soft Skilss', 'textarea', true, ''),
+    ('What are your leadership strengths, and what areas are you actively working to improve?', 'The Team', 'Personality and Soft Skilss', 'textarea', true, ''),
+    ('How do you maintain your focus and energy while balancing the demands of entrepreneurship?', 'The Team', 'Personality and Soft Skilss', 'textarea', true, '');
+
+-- SECTION: The History nothing in notion yet
+-- INSERT INTO project_questions (question, section, sub_section, input_type, required, validations) VALUES
+
+-- SECTION: The Financials
+INSERT INTO project_questions (question, section, sub_section, input_type, required, validations) VALUES
+    -- SUB-SECTION: Financial and Strategic Understanding
+    ('Do you clearly understand your financial metrics (e.g., revenue, expenses, cash flow)?', 'The Financials', 'Financial and Strategic Understanding', 'textarea', true, ''),
+    ('What is your business scaling strategy, and how will you fund growth?', 'The Financials', 'Financial and Strategic Understanding', 'textarea', true, ''),
+    ('How do you prioritize spending and allocate resources?', 'The Financials', 'Financial and Strategic Understanding', 'textarea', true, ''),
+    ('What is your exit strategy, and how does it align with investor expectations?', 'The Financials', 'Financial and Strategic Understanding', 'textarea', true, ''),
+
+    -- SUB-SECTION: Financial Overview
+    ('What is the current revenue and growth rate?', 'The Financials', 'Financial Overview', 'textarea', true, ''),
+    ('What are the gross and net profit margins?', 'The Financials', 'Financial Overview', 'textarea', true, ''),
+    ('What is the customer acquisition cost (CAC) and lifetime value (LTV)?', 'The Financials', 'Financial Overview', 'textarea', true, ''),
+    ('Are the financial projections realistic and based on credible assumptions?', 'The Financials', 'Financial Overview', 'textarea', true, ''),
+    ('What is the current burn rate, and how much runway is left?', 'The Financials', 'Financial Overview', 'textarea', true, ''),
+
+    -- SUB-SECTION: Financial Needs & Usage
+    ('How much funding is the startup seeking, and what will it be used for?', 'The Financials', 'Financial Needs & Usage', 'textarea', true, ''),
+    ('What milestones will the funding help achieve?', 'The Financials', 'Financial Needs & Usage', 'textarea', true, ''),
+    ('Are there other sources of funding (e.g., grants, loans, existing investors)?', 'The Financials', 'Financial Needs & Usage', 'textarea', true, ''),
+    ('What is the proposed valuation, and is it justified?', 'The Financials', 'Financial Needs & Usage', 'textarea', true, '');
+
 
 -- +goose StatementEnd
 
 -- +goose Down
 -- +goose StatementBegin
-DELETE FROM project_questions WHERE section = 'business_overview'; 
+DELETE FROM project_questions; 
+
+ALTER TABLE IF EXISTS project_questions
+DROP COLUMN options;
 
 ALTER TABLE IF EXISTS project_questions
 DROP COLUMN input_type;
 
 ALTER TABLE IF EXISTS project_questions
 DROP COLUMN sub_section;
+
+DROP TYPE IF EXISTS input;
 -- +goose StatementEnd

--- a/backend/.sqlc/migrations/20241226195458_add_default_questions.sql
+++ b/backend/.sqlc/migrations/20241226195458_add_default_questions.sql
@@ -1,26 +1,151 @@
 -- +goose Up
-INSERT INTO project_questions (id, question, section, required, validations) VALUES 
-    (
-        gen_random_uuid(), 
-        'What is the core product or service, and what problem does it solve?', 
-        'business_overview',
-        true,
-        'min=100'  -- Warning if less than 100 chars
-    ),
-    (
-        gen_random_uuid(), 
-        'What is the unique value proposition?', 
-        'business_overview',
-        true,
-        'min=50'  -- Warning if less than 50 chars
-    ),
-    (
-        gen_random_uuid(), 
-        'Company website', 
-        'business_overview',
-        true,
-        'url'  -- Error if not valid URL
-    );
+-- +goose StatementBegin
+-- alter project questions table to include a sub-section column
+-- sub-section helps organize questions into smaller groups (how they are grouped in UI/UX)
+ALTER TABLE IF EXISTS project_questions
+ADD COLUMN sub_section VARCHAR(255) NOT NULL;
+
+-- enum type for different input types
+CREATE TYPE input AS ENUM (
+    'textinput', -- single line input
+    'textarea', -- multi-line input
+    'select', -- single selection/dropdown input
+    'checkbox', -- checkbox question with one or more choices
+    'radio', -- single selection with one or more choices
+    'team', -- team creation input
+    'file' -- file upload input
+);
+-- alter project questions table to include the type of input the question is for frontend use.
+ALTER TABLE IF EXISTS project_questions
+ADD COLUMN input_type input NOT NULL;
+
+-- alter project questions table to include optional options for input types: checkboxes, select, radio
+ALTER TABLE IF EXISTS project_questions
+ADD COLUMN options VARCHAR(255)[];
+
+-- seed database with initial default questions
+
+-- SECTION: The Basics
+INSERT INTO project_questions (question, section, sub_section, input_type, required, validations) VALUES 
+    -- SUB-SECTION: Business Overview
+    ('What is the core product or service, and what problem does it solve?', 'The Basics', 'Business Overview', 'textarea', true, ''),
+    ('What is the unique value proposition?', 'The Basics', 'Business Overview', true, ''),
+    ('What is the size and growth rate of the target market?', 'The Basics', 'Business Overview', 'textarea', true, ''),
+    ('Who are the main competitors, and how is the business differentiated from them?', 'The Basics', 'Business Overview', 'textarea', true, ''),
+
+    -- SUB-SECTION: Market Analysis
+    ('Who are the target customers, and what are their needs?', 'The Basics', 'Market Analysis', 'textarea', true, ''),
+    ('What is the total addressable market (TAM), and how much can the startup realistically capture?', 'The Basics', 'Market Analysis', 'textarea', true, ''),
+    ('What are the main market trends and drivers?', 'The Basics', 'Market Analysis', 'textarea', true, ''),
+    ('What are the main market trends and drivers?', 'The Basics', 'Market Analysis', 'textarea', true, ''),
+    ('Are there any significant barriers to entry or competitive advantages?', 'The Basics', 'Market Analysis', 'textarea', true, ''),
+
+    -- SUB-SECTION: Product or Service
+    ('What stage of development is the product in (idea, prototype, MVP, production)?', 'The Basics', 'Product or Service', 'textarea', true, ''),
+    ('What feedback has been received from early customers or beta users?', 'The Basics', 'Product or Service', 'textarea', true, ''),
+    ('Are any intellectual property (IP) protections, such as patents or trademarks in place?', 'The Basics', 'Product or Service', 'textarea', true, ''),
+    ('How scalable is the product/service?', 'The Basics', 'Product or Service', 'textarea', true, ''),
+
+    -- SUB-SECTION: Traction
+    ('How many customers or users does the startup currently have?', 'The Basics', 'Traction', 'textarea', true, ''),
+    ('Are there partnerships, contracts, or letters of interest in place?', 'The Basics', 'Traction', 'textarea', true, ''),
+    ('Has the startup received media coverage, awards, or endorsements?', 'The Basics', 'Traction', 'textarea', true, ''),
+    ('What milestones has the startup achieved so far?', 'The Basics', 'Traction', 'textarea', true, ''),
+
+    -- SUB-SECTION: Risks and Challenges
+    ('What are the major risks (market, operational, competitive, regulatory)?', 'The Basics', 'Risks and Challenges', 'textarea', true, ''),
+    ('How does the startup plan to mitigate these risks?', 'The Basics', 'Risks and Challenges', 'textarea', true, ''),
+    ('Are there any pending legal or compliance issues?', 'The Basics', 'Risks and Challenges', 'textarea', true, ''),
+    ('Are there any key dependencies (e.g., suppliers, technology)?', 'The Basics', 'Risks and Challenges', 'textarea', true, ''),
+
+    -- SUB-SECTION: Exit Strategy
+    ('What is the long-term vision for the business?', 'The Basics', 'Exit Strategy', 'textarea', true, ''),
+    ('Does the startup have a defined exit strategy (e.g., acquisition, IPO)?', 'The Basics', 'Exit Strategy', 'textarea', true, ''),
+    ('Are there potential acquirers or exit opportunities in the market?', 'The Basics', 'Exit Strategy', 'textarea', true, ''),
+    ('What is the projected return on investment (ROI) for investors?', 'The Basics', 'Exit Strategy', 'textarea', true, ''),
+
+    -- SUB-SECTION: Alignment and Impact
+    ('Does the startup align with SPUR’s values and mission?', 'The Basics', 'Alignment and Impact', 'textarea', true, ''),
+    ('What is the potential for a positive impact?', 'The Basics', 'Alignment and Impact', 'textarea', true, ''),
+    ('What is their mission?', 'The Basics', 'Alignment and Impact', 'textarea', true, ''),
+    ('How does the startup contribute to local or global communities?', 'The Basics', 'Alignment and Impact', 'textarea', true, ''),
+
+    -- SUB-SECTION: Legal and Compliance
+    ('Is the company properly registered and in good legal standing?', 'The Basics', 'Legal and Compliance', 'textarea', true, ''),
+    ('Are the ownership and equity structures clear and documented?', 'The Basics', 'Legal and Compliance', 'textarea', true, ''),
+    ('Are there any outstanding legal disputes or liabilities?', 'The Basics', 'Legal and Compliance', 'textarea', true, ''),
+    ('Does the company comply with industry-specific regulations?', 'The Basics', 'Legal and Compliance', 'textarea', true, ''),
+
+    -- SUB-SECTION: Strategic Fit with SPUR
+    ('How does the startup align with SPUR’s strategic priorities and goals?', 'The Basics', 'Strategic Fit with SPUR', 'textarea', true, ''),
+    ('Are there potential synergies with other startups or partners from SPUR?', 'The Basics', 'Strategic Fit with SPUR', 'textarea', true, ''),
+    ('Can SPUR provide unique value beyond funding (e.g., mentorship, networking)?', 'The Basics', 'Strategic Fit with SPUR', 'textarea', true, '');
+
+-- SECTION: The Team
+INSERT INTO project_questions (question, section, sub_section, input_type, required, validations) VALUES 
+    -- SUB-SECTION: Team Members
+    ('', 'The Team', 'Team Members', 'team', false, ''),
+
+    -- SUB-SECTION: Team Background
+    ('Who are the founders and key team members, and what are their backgrounds?', 'The Team', 'Team Background', 'textarea', true, ''),
+    ('Do they have relevant experience in the industry?', 'The Team', 'Team Background', 'textarea', true, ''),
+    ('How committed are the founders (e.g., full-time, personal investment)?', 'The Team', 'Team Background', 'textarea', true, ''),
+    ('Does the team have a balanced skill set (technical, operational, marketing, finance)?', 'The Team', 'Team Background', 'textarea', true, ''),
+
+    -- SUB-SECTION: Personal Background
+    ('What is your professional and educational background?', 'The Team', 'Personal Background', 'textarea', true, ''),
+    ('What relevant experience do you have in this industry or market?', 'The Team', 'Personal Background', 'textarea', true, ''),
+    ('Have you successfully launched or managed any startups or businesses before? If so, what were the outcomes?', 'The Team', 'Personal Background', 'textarea', true, ''),
+    ('What lessons did you learn from your previous ventures, both successful and unsuccessful?', 'The Team', 'Personal Background', 'textarea', true, ''),
+    ('How well do you understand the technical and operational aspects of your business?', 'The Team', 'Personal Background', 'textarea', true, ''),
+
+    -- SUB-SECTION: Vision and Motivation
+    ('What inspired you to start this business?', 'The Team', 'Vision and Motivation', 'textarea', true, ''),
+    ('What is the long-term vision for the company, and how do you plan to achieve it?', 'The Team', 'Vision and Motivation', 'textarea', true, ''),
+    ('What motivates you to continue pursuing this business, especially during challenging times?', 'The Team', 'Vision and Motivation', 'textarea', true, ''),
+    ('How do you measure success for yourself and your business?', 'The Team', 'Vision and Motivation', 'textarea', true, ''),
+
+    -- SUB-SECTION: Leadership
+    ('What is your leadership style?', 'The Team', 'Leadership', 'textarea', true, ''),
+    ('How do you manage and motivate your team?', 'The Team', 'Leadership', 'textarea', true, ''),
+    ('How do you handle conflict within the team and/or with external stakeholders?', 'The Team', 'Leadership', 'textarea', true, ''),
+    ('Are you comfortable delegating responsibilities, or do you tend to take on too much yourself?', 'The Team', 'Leadership', 'textarea', true, ''),
+    ('What processes do you have in place to attract, retain, and develop talent?', 'The Team', 'Leadership', 'textarea', true, ''),
+
+    -- SUB-SECTION: Personal Commitment
+    ('How committed are you to this venture?', 'The Team', 'Personal Commitment', 'textarea', true, ''),
+    ('How much personal capital have you invested in the business?', 'The Team', 'Personal Commitment', 'textarea', true, ''),
+    ('Are there any other obligations or ventures that could divide your focus?', 'The Team', 'Personal Commitment', 'textarea', true, ''),
+    ('How long do you see yourself staying actively involved in the business?', 'The Team', 'Personal Commitment', 'textarea', true, ''),
+
+    -- SUB-SECTION: Knowledge and Preparedness
+    ('How well do you understand your target market, customer needs, and competitive landscape?', 'The Team', 'Knowledge and Preparedness', 'textarea', true, ''),
+    ('What research or validation have you done to confirm demand for your product or service?', 'The Team', 'Knowledge and Preparedness', 'textarea', true, ''),
+    ('Do you have a roadmap for the next 12 months, 3 years, and 5 years?', 'The Team', 'Knowledge and Preparedness', 'textarea', true, ''),
+    ('What contingencies have you planned for potential risks or challenges?', 'The Team', 'Knowledge and Preparedness', 'textarea', true, ''),
+
+    -- SUB-SECTION: Problem-Solving and Resillience
+    ('Can you share an example of a major challenge you’ve faced and how you resolved it', 'The Team', 'Problem-Solving and Resillience', 'textarea', true, ''),
+    ('How do you make decisions under pressure or with incomplete information?', 'The Team', 'Problem-Solving and Resillience', 'textarea', true, ''),
+    ('What are the biggest risks to your business, and how do you plan to mitigate them', 'The Team', 'Problem-Solving and Resillience', 'textarea', true, ''),
+    ('How do you handle setbacks or failures?', 'The Team', 'Problem-Solving and Resillience', 'textarea', true, ''),
+    ('Relationships and Networking', 'The Team', 'Problem-Solving and Resillience', 'checkbox', true, ''),
+    ('Can you share an example of a major challenge you’ve faced and how you resolved it', 'The Team', 'Problem-Solving and Resillience', 'textarea', true, ''),
+    ('Can you share an example of a major challenge you’ve faced and how you resolved it', 'The Team', 'Problem-Solving and Resillience', 'textarea', true, ''),
+    ('Can you share an example of a major challenge you’ve faced and how you resolved it', 'The Team', 'Problem-Solving and Resillience', 'textarea', true, '');
+
+-- TODO: add remaining questions for problem solving
+-- TODO: design new schema that can represent the different types of inputs for each question.
+
+-- +goose StatementEnd
 
 -- +goose Down
+-- +goose StatementBegin
 DELETE FROM project_questions WHERE section = 'business_overview'; 
+
+ALTER TABLE IF EXISTS project_questions
+DROP COLUMN input_type;
+
+ALTER TABLE IF EXISTS project_questions
+DROP COLUMN sub_section;
+-- +goose StatementEnd

--- a/backend/.sqlc/migrations/20241226195458_add_default_questions.sql
+++ b/backend/.sqlc/migrations/20241226195458_add_default_questions.sql
@@ -1,16 +1,5 @@
 -- +goose Up
 -- +goose StatementBegin
--- enum type for different input types
-CREATE TYPE input AS ENUM (
-    'textinput', -- single line input
-    'textarea', -- multi-line input
-    'select', -- single selection/dropdown input
-    'checkbox', -- checkbox question with one or more choices
-    'radio', -- single selection with one or more choices
-    -- team creation is a list of objects with the basic information of a team member
-    'team', -- team creation input
-    'file' -- file upload input
-);
 
 -- alter project questions table to include a sub-section column
 -- sub-section helps organize questions into smaller groups (how they are grouped in UI/UX)
@@ -19,7 +8,7 @@ ADD COLUMN sub_section VARCHAR(255) NOT NULL;
 
 -- alter project questions table to include the type of input the question is for frontend use.
 ALTER TABLE IF EXISTS project_questions
-ADD COLUMN input_type input NOT NULL;
+ADD COLUMN input_type VARCHAR(255) NOT NULL;
 
 -- alter project questions table to include optional options for input types: checkboxes, select, radio
 ALTER TABLE IF EXISTS project_questions
@@ -31,14 +20,14 @@ ADD COLUMN options VARCHAR(255)[];
 INSERT INTO project_questions (sub_section_order, question, section, sub_section, input_type, options, required, validations) VALUES 
     -- SUB-SECTION: Company Pitch
     (0, 'Include a link to a 5-minute video of you or your company pitching itself.', 'The Basics', 'Company Pitch', 'textinput', NULL, false, 'url'),
-    (1, 'Please upload a pitch deck.', 'The Basics', 'Company Pitch', 'textinput|file', false, 'url'),
+    (1, 'Please upload a pitch deck.', 'The Basics', 'Company Pitch', 'textinput|file', NULL, false, 'url'),
 
     -- SUB-SECTION: Business Overview
     (0, 'What is the core product or service, and what problem does it solve?', 'The Basics', 'Business Overview', 'textarea', NULL, true, ''),
     (1, 'What is the unique value proposition?', 'The Basics', 'Business Overview', 'textarea', NULL, true, ''),
     (2, 'Who are the main competitors, and how is the business differentiated from them?', 'The Basics', 'Business Overview', 'textarea', NULL, true, ''),
-    (3, "What is the company's mission?", 'The Basics', 'Business Overview', 'textinput', NULL, true, ''),
-    (4, "What is the company's business plan?", 'The Basics', 'Business Overview', 'textinput|file', NULL, true, ''),
+    (3, 'What is the company''s mission?', 'The Basics', 'Business Overview', 'textinput', NULL, true, ''),
+    (4, 'What is the company''s business plan?', 'The Basics', 'Business Overview', 'textinput|file', NULL, true, ''),
 
     -- SUB-SECTION: Market Analysis & Research
     (0, 'Who are the target customers, and what are their needs?', 'The Basics', 'Market Analysis & Research', 'textarea', NULL, true, ''),
@@ -46,8 +35,8 @@ INSERT INTO project_questions (sub_section_order, question, section, sub_section
     (2, 'What is the total addressable market (TAM), and how much can the startup realistically capture?', 'The Basics', 'Market Analysis & Research', 'textarea', NULL, true, ''),
     (3, 'What are the main market trends and drivers?', 'The Basics', 'Market Analysis & Research', 'textarea', NULL, false, ''),
     (4, 'Are there any significant barriers to entry or competitive advantages?', 'The Basics', 'Market Analysis & Research', 'textarea', NULL, false, ''),
-    (5, "Do you have any market research-related documents you'd like to inlcude?", 'The Basics', 'Market Analysis & Research', 'textinput|file', NULL, false, 'url'),
-    (6, "Do you have any customer data-related documents you'd like to include?", 'The Basics', 'Market Analysis & Research', 'textinput|file', NULL, false, 'url'),
+    (5, 'Do you have any market research-related documents you''d like to inlcude?', 'The Basics', 'Market Analysis & Research', 'textinput|file', NULL, false, 'url'),
+    (6, 'Do you have any customer data-related documents you''d like to include?', 'The Basics', 'Market Analysis & Research', 'textinput|file', NULL, false, 'url'),
 
     -- SUB-SECTION: Product or Service
     (0, 'What stage of development is the product in (idea, prototype, MVP, production)?', 'The Basics', 'Product or Service', 'select', '{Idea,Prototype,MVP,Production}', true, ''),
@@ -74,10 +63,10 @@ INSERT INTO project_questions (sub_section_order, question, section, sub_section
 
     -- SUB-SECTION: Alignment and Impact
     (0, 'Does the startup align with SPUR’s values and mission?', 'The Basics', 'Alignment and Impact', 'textarea', NULL, true, ''),
-    (1, "How does the startup align with SPUR's strategic priorities and goals?", 'The Basics', 'Alignment and Impact', 'textarea', NULL, true, ''),
-    (2, "Are there potential synergies with other startups or partners from SPUR?", 'The Basics', 'Alignment and Impact', 'textarea', NULL, true, ''),
-    (3, "Can SPUR provide unique value beyond funding (e.g., mentorship, networking)?", 'The Basics', 'Alignment and Impact', 'textarea', NULL, true, ''),
-    (4, "Are you open to mentorship, guidance or collaboration from SPUR or its network?", 'The Basics', 'Alignment and Impact', 'textarea', NULL, true, ''),
+    (1, 'How does the startup align with SPUR''s strategic priorities and goals?', 'The Basics', 'Alignment and Impact', 'textarea', NULL, true, ''),
+    (2, 'Are there potential synergies with other startups or partners from SPUR?', 'The Basics', 'Alignment and Impact', 'textarea', NULL, true, ''),
+    (3, 'Can SPUR provide unique value beyond funding (e.g., mentorship, networking)?', 'The Basics', 'Alignment and Impact', 'textarea', NULL, true, ''),
+    (4, 'Are you open to mentorship, guidance or collaboration from SPUR or its network?', 'The Basics', 'Alignment and Impact', 'textarea', NULL, true, ''),
     (5, 'What is the potential for a positive impact?', 'The Basics', 'Alignment and Impact', 'textarea', NULL, true, ''),
     (6, 'How does the startup contribute to local or global communities?', 'The Basics', 'Alignment and Impact', 'textarea', NULL, true, ''),
 
@@ -86,95 +75,95 @@ INSERT INTO project_questions (sub_section_order, question, section, sub_section
     (1, 'Are the ownership and equity structures clear and documented?', 'The Basics', 'Legal and Compliance', 'textinput', NULL, true, ''),
     (2, 'Are there any outstanding legal disputes or liabilities?', 'The Basics', 'Legal and Compliance', 'textinput', NULL, true, ''),
     (3, 'Does the company comply with industry-specific regulations?', 'The Basics', 'Legal and Compliance', 'textinput', NULL, true, ''),
-    (4, "Do you have any contracts, agreements, or letters of intent you'd like to include?", 'The Basics', 'Legal and Compliance', 'textinput|file', NULL, false, 'url'),
+    (4, 'Do you have any contracts, agreements, or letters of intent you''d like to include?', 'The Basics', 'Legal and Compliance', 'textinput|file', NULL, false, 'url');
 
 -- SECTION: The Team
-INSERT INTO project_questions (question, section, sub_section, input_type, required, validations) VALUES 
+INSERT INTO project_questions (sub_section_order, question, section, sub_section, input_type, required, validations) VALUES 
     -- SUB-SECTION: Team Members
-    ('', 'The Team', 'Team Members', 'team', true, ''),
+    (0, '', 'The Team', 'Team Members', 'team', true, ''),
 
     -- SUB-SECTION: Team Background
-    ('Who are the founders and key team members, and what are their backgrounds?', 'The Team', 'Team Background', 'textarea', true, ''),
-    ('Do they have relevant experience in the industry?', 'The Team', 'Team Background', 'textarea', true, ''),
-    ('How committed are the founders (e.g., full-time, personal investment)?', 'The Team', 'Team Background', 'textarea', true, ''),
-    ('Does the team have a balanced skill set (technical, operational, marketing, finance)?', 'The Team', 'Team Background', 'textarea', true, ''),
+    (0, 'Who are the founders and key team members, and what are their backgrounds?', 'The Team', 'Team Background', 'textarea', true, ''),
+    (1, 'Do they have relevant experience in the industry?', 'The Team', 'Team Background', 'textarea', true, ''),
+    (2, 'How committed are the founders (e.g., full-time, personal investment)?', 'The Team', 'Team Background', 'textarea', true, ''),
+    (3, 'Does the team have a balanced skill set (technical, operational, marketing, finance)?', 'The Team', 'Team Background', 'textarea', true, ''),
 
     -- SUB-SECTION: Personal Background
-    ('What is your professional and educational background?', 'The Team', 'Personal Background', 'textarea', true, ''),
-    ('What relevant experience do you have in this industry or market?', 'The Team', 'Personal Background', 'textarea', true, ''),
-    ('Have you successfully launched or managed any startups or businesses before? If so, what were the outcomes?', 'The Team', 'Personal Background', 'textarea', true, ''),
-    ('What lessons did you learn from your previous ventures, both successful and unsuccessful?', 'The Team', 'Personal Background', 'textarea', true, ''),
-    ('How well do you understand the technical and operational aspects of your business?', 'The Team', 'Personal Background', 'textarea', true, ''),
+    (0, 'What is your professional and educational background?', 'The Team', 'Personal Background', 'textarea', true, ''),
+    (1, 'What relevant experience do you have in this industry or market?', 'The Team', 'Personal Background', 'textarea', true, ''),
+    (2, 'Have you successfully launched or managed any startups or businesses before? If so, what were the outcomes?', 'The Team', 'Personal Background', 'textarea', true, ''),
+    (3, 'What lessons did you learn from your previous ventures, both successful and unsuccessful?', 'The Team', 'Personal Background', 'textarea', true, ''),
+    (4, 'How well do you understand the technical and operational aspects of your business?', 'The Team', 'Personal Background', 'textarea', true, ''),
 
     -- SUB-SECTION: Vision and Motivation
-    ('What inspired you to start this business?', 'The Team', 'Vision and Motivation', 'textarea', true, ''),
-    ('What is the long-term vision for the company, and how do you plan to achieve it?', 'The Team', 'Vision and Motivation', 'textarea', true, ''),
-    ('What motivates you to continue pursuing this business, especially during challenging times?', 'The Team', 'Vision and Motivation', 'textarea', true, ''),
-    ('How do you measure success for yourself and your business?', 'The Team', 'Vision and Motivation', 'textarea', true, ''),
+    (0, 'What inspired you to start this business?', 'The Team', 'Vision and Motivation', 'textarea', true, ''),
+    (0, 'What is the long-term vision for the company, and how do you plan to achieve it?', 'The Team', 'Vision and Motivation', 'textarea', true, ''),
+    (0, 'What motivates you to continue pursuing this business, especially during challenging times?', 'The Team', 'Vision and Motivation', 'textarea', true, ''),
+    (0, 'How do you measure success for yourself and your business?', 'The Team', 'Vision and Motivation', 'textarea', true, ''),
 
     -- SUB-SECTION: Leadership
-    ('What is your leadership style?', 'The Team', 'Leadership', 'textarea', true, ''),
-    ('How do you manage and motivate your team?', 'The Team', 'Leadership', 'textarea', true, ''),
-    ('How do you handle conflict within the team and/or with external stakeholders?', 'The Team', 'Leadership', 'textarea', true, ''),
-    ('Are you comfortable delegating responsibilities, or do you tend to take on too much yourself?', 'The Team', 'Leadership', 'textarea', true, ''),
-    ('What processes do you have in place to attract, retain, and develop talent?', 'The Team', 'Leadership', 'textarea', true, ''),
+    (0, 'What is your leadership style?', 'The Team', 'Leadership', 'textarea', true, ''),
+    (0, 'How do you manage and motivate your team?', 'The Team', 'Leadership', 'textarea', true, ''),
+    (0, 'How do you handle conflict within the team and/or with external stakeholders?', 'The Team', 'Leadership', 'textarea', true, ''),
+    (0, 'Are you comfortable delegating responsibilities, or do you tend to take on too much yourself?', 'The Team', 'Leadership', 'textarea', true, ''),
+    (0, 'What processes do you have in place to attract, retain, and develop talent?', 'The Team', 'Leadership', 'textarea', true, ''),
 
     -- SUB-SECTION: Personal Commitment
-    ('How committed are you to this venture?', 'The Team', 'Personal Commitment', 'textarea', true, ''),
-    ('How much personal capital have you invested in the business?', 'The Team', 'Personal Commitment', 'textarea', true, ''),
-    ('Are there any other obligations or ventures that could divide your focus?', 'The Team', 'Personal Commitment', 'textarea', true, ''),
-    ('How long do you see yourself staying actively involved in the business?', 'The Team', 'Personal Commitment', 'textarea', true, ''),
+    (0, 'How committed are you to this venture?', 'The Team', 'Personal Commitment', 'textarea', true, ''),
+    (0, 'How much personal capital have you invested in the business?', 'The Team', 'Personal Commitment', 'textarea', true, ''),
+    (0, 'Are there any other obligations or ventures that could divide your focus?', 'The Team', 'Personal Commitment', 'textarea', true, ''),
+    (0, 'How long do you see yourself staying actively involved in the business?', 'The Team', 'Personal Commitment', 'textarea', true, ''),
 
     -- SUB-SECTION: Knowledge and Preparedness
-    ('How well do you understand your target market, customer needs, and competitive landscape?', 'The Team', 'Knowledge and Preparedness', 'textarea', true, ''),
-    ('What research or validation have you done to confirm demand for your product or service?', 'The Team', 'Knowledge and Preparedness', 'textarea', true, ''),
-    ('Do you have a roadmap for the next 12 months, 3 years, and 5 years?', 'The Team', 'Knowledge and Preparedness', 'textarea', true, ''),
-    ('What contingencies have you planned for potential risks or challenges?', 'The Team', 'Knowledge and Preparedness', 'textarea', true, ''),
+    (0, 'How well do you understand your target market, customer needs, and competitive landscape?', 'The Team', 'Knowledge and Preparedness', 'textarea', true, ''),
+    (0, 'What research or validation have you done to confirm demand for your product or service?', 'The Team', 'Knowledge and Preparedness', 'textarea', true, ''),
+    (0, 'Do you have a roadmap for the next 12 months, 3 years, and 5 years?', 'The Team', 'Knowledge and Preparedness', 'textarea', true, ''),
+    (0, 'What contingencies have you planned for potential risks or challenges?', 'The Team', 'Knowledge and Preparedness', 'textarea', true, ''),
 
     -- SUB-SECTION: Problem-Solving and Resillience
-    ('Can you share an example of a major challenge you’ve faced and how you resolved it', 'The Team', 'Problem-Solving and Resillience', 'textarea', true, ''),
-    ('How do you make decisions under pressure or with incomplete information?', 'The Team', 'Problem-Solving and Resillience', 'textarea', true, ''),
-    ('What are the biggest risks to your business, and how do you plan to mitigate them', 'The Team', 'Problem-Solving and Resillience', 'textarea', true, ''),
-    ('How do you handle setbacks or failures?', 'The Team', 'Problem-Solving and Resillience', 'textarea', true, ''),
-    ('Relationships and Networking', 'The Team', 'Problem-Solving and Resillience', 'checkbox', true, ''),
-    ('Can you share an example of a major challenge you’ve faced and how you resolved it', 'The Team', 'Problem-Solving and Resillience', 'textarea', true, ''),
-    ('Can you share an example of a major challenge you’ve faced and how you resolved it', 'The Team', 'Problem-Solving and Resillience', 'textarea', true, ''),
-    ('Can you share an example of a major challenge you’ve faced and how you resolved it', 'The Team', 'Problem-Solving and Resillience', 'textarea', true, ''),
+    (0, 'Can you share an example of a major challenge you’ve faced and how you resolved it', 'The Team', 'Problem-Solving and Resillience', 'textarea', true, ''),
+    (0, 'How do you make decisions under pressure or with incomplete information?', 'The Team', 'Problem-Solving and Resillience', 'textarea', true, ''),
+    (0, 'What are the biggest risks to your business, and how do you plan to mitigate them', 'The Team', 'Problem-Solving and Resillience', 'textarea', true, ''),
+    (0, 'How do you handle setbacks or failures?', 'The Team', 'Problem-Solving and Resillience', 'textarea', true, ''),
+    (0, 'Relationships and Networking', 'The Team', 'Problem-Solving and Resillience', 'checkbox', true, ''),
+    (0, 'Can you share an example of a major challenge you’ve faced and how you resolved it', 'The Team', 'Problem-Solving and Resillience', 'textarea', true, ''),
+    (0, 'Can you share an example of a major challenge you’ve faced and how you resolved it', 'The Team', 'Problem-Solving and Resillience', 'textarea', true, ''),
+    (0, 'Can you share an example of a major challenge you’ve faced and how you resolved it', 'The Team', 'Problem-Solving and Resillience', 'textarea', true, ''),
 
     -- SUB-SECTION: Relationships and Networking
-    ('What key partnerships, relationships, or networks have you built to support your business?', 'The Team', 'Relationships and Networking', 'textarea', true, ''),
-    ('How do you approach building relationships with customers, suppliers, and investors?', 'The Team', 'Relationships and Networking', 'textarea', true, ''),
-    ('Are you active in relevant industry communities or events?', 'The Team', 'Relationships and Networking', 'textarea', true, ''),
+    (0, 'What key partnerships, relationships, or networks have you built to support your business?', 'The Team', 'Relationships and Networking', 'textarea', true, ''),
+    (0, 'How do you approach building relationships with customers, suppliers, and investors?', 'The Team', 'Relationships and Networking', 'textarea', true, ''),
+    (0, 'Are you active in relevant industry communities or events?', 'The Team', 'Relationships and Networking', 'textarea', true, ''),
 
     -- SUB-SECTION: Personality and Soft Skills
-    ('How would your team describe your management style and personality?', 'The Team', 'Personality and Soft Skilss', 'textarea', true, ''),
-    ('How do you handle feedback or criticism?', 'The Team', 'Personality and Soft Skilss', 'textarea', true, ''),
-    ('What are your leadership strengths, and what areas are you actively working to improve?', 'The Team', 'Personality and Soft Skilss', 'textarea', true, ''),
-    ('How do you maintain your focus and energy while balancing the demands of entrepreneurship?', 'The Team', 'Personality and Soft Skilss', 'textarea', true, '');
+    (0, 'How would your team describe your management style and personality?', 'The Team', 'Personality and Soft Skilss', 'textarea', true, ''),
+    (0, 'How do you handle feedback or criticism?', 'The Team', 'Personality and Soft Skilss', 'textarea', true, ''),
+    (0, 'What are your leadership strengths, and what areas are you actively working to improve?', 'The Team', 'Personality and Soft Skilss', 'textarea', true, ''),
+    (0, 'How do you maintain your focus and energy while balancing the demands of entrepreneurship?', 'The Team', 'Personality and Soft Skilss', 'textarea', true, '');
 
 -- SECTION: The History nothing in notion yet
 -- INSERT INTO project_questions (question, section, sub_section, input_type, required, validations) VALUES
 
 -- SECTION: The Financials
-INSERT INTO project_questions (question, section, sub_section, input_type, required, validations) VALUES
+INSERT INTO project_questions (sub_section_order, question, section, sub_section, input_type, required, validations) VALUES
     -- SUB-SECTION: Financial and Strategic Understanding
-    ('Do you clearly understand your financial metrics (e.g., revenue, expenses, cash flow)?', 'The Financials', 'Financial and Strategic Understanding', 'textarea', true, ''),
-    ('What is your business scaling strategy, and how will you fund growth?', 'The Financials', 'Financial and Strategic Understanding', 'textarea', true, ''),
-    ('How do you prioritize spending and allocate resources?', 'The Financials', 'Financial and Strategic Understanding', 'textarea', true, ''),
-    ('What is your exit strategy, and how does it align with investor expectations?', 'The Financials', 'Financial and Strategic Understanding', 'textarea', true, ''),
+    (0, 'Do you clearly understand your financial metrics (e.g., revenue, expenses, cash flow)?', 'The Financials', 'Financial and Strategic Understanding', 'textarea', true, ''),
+    (0, 'What is your business scaling strategy, and how will you fund growth?', 'The Financials', 'Financial and Strategic Understanding', 'textarea', true, ''),
+    (0, 'How do you prioritize spending and allocate resources?', 'The Financials', 'Financial and Strategic Understanding', 'textarea', true, ''),
+    (0, 'What is your exit strategy, and how does it align with investor expectations?', 'The Financials', 'Financial and Strategic Understanding', 'textarea', true, ''),
 
     -- SUB-SECTION: Financial Overview
-    ('What is the current revenue and growth rate?', 'The Financials', 'Financial Overview', 'textarea', true, ''),
-    ('What are the gross and net profit margins?', 'The Financials', 'Financial Overview', 'textarea', true, ''),
-    ('What is the customer acquisition cost (CAC) and lifetime value (LTV)?', 'The Financials', 'Financial Overview', 'textarea', true, ''),
-    ('Are the financial projections realistic and based on credible assumptions?', 'The Financials', 'Financial Overview', 'textarea', true, ''),
-    ('What is the current burn rate, and how much runway is left?', 'The Financials', 'Financial Overview', 'textarea', true, ''),
+    (0, 'What is the current revenue and growth rate?', 'The Financials', 'Financial Overview', 'textarea', true, ''),
+    (0, 'What are the gross and net profit margins?', 'The Financials', 'Financial Overview', 'textarea', true, ''),
+    (0, 'What is the customer acquisition cost (CAC) and lifetime value (LTV)?', 'The Financials', 'Financial Overview', 'textarea', true, ''),
+    (0, 'Are the financial projections realistic and based on credible assumptions?', 'The Financials', 'Financial Overview', 'textarea', true, ''),
+    (0, 'What is the current burn rate, and how much runway is left?', 'The Financials', 'Financial Overview', 'textarea', true, ''),
 
     -- SUB-SECTION: Financial Needs & Usage
-    ('How much funding is the startup seeking, and what will it be used for?', 'The Financials', 'Financial Needs & Usage', 'textarea', true, ''),
-    ('What milestones will the funding help achieve?', 'The Financials', 'Financial Needs & Usage', 'textarea', true, ''),
-    ('Are there other sources of funding (e.g., grants, loans, existing investors)?', 'The Financials', 'Financial Needs & Usage', 'textarea', true, ''),
-    ('What is the proposed valuation, and is it justified?', 'The Financials', 'Financial Needs & Usage', 'textarea', true, '');
+    (0, 'How much funding is the startup seeking, and what will it be used for?', 'The Financials', 'Financial Needs & Usage', 'textarea', true, ''),
+    (0, 'What milestones will the funding help achieve?', 'The Financials', 'Financial Needs & Usage', 'textarea', true, ''),
+    (0, 'Are there other sources of funding (e.g., grants, loans, existing investors)?', 'The Financials', 'Financial Needs & Usage', 'textarea', true, ''),
+    (0, 'What is the proposed valuation, and is it justified?', 'The Financials', 'Financial Needs & Usage', 'textarea', true, '');
 
 
 -- +goose StatementEnd
@@ -191,6 +180,4 @@ DROP COLUMN input_type;
 
 ALTER TABLE IF EXISTS project_questions
 DROP COLUMN sub_section;
-
-DROP TYPE IF EXISTS input;
 -- +goose StatementEnd

--- a/backend/.sqlc/migrations/20241226195458_add_default_questions.sql
+++ b/backend/.sqlc/migrations/20241226195458_add_default_questions.sql
@@ -29,7 +29,7 @@ ADD COLUMN options VARCHAR(255)[];
 INSERT INTO project_questions (question, section, sub_section, input_type, required, validations) VALUES 
     -- SUB-SECTION: Business Overview
     ('What is the core product or service, and what problem does it solve?', 'The Basics', 'Business Overview', 'textarea', true, ''),
-    ('What is the unique value proposition?', 'The Basics', 'Business Overview', true, ''),
+    ('What is the unique value proposition?', 'The Basics', 'Business Overview', 'textarea', true, ''),
     ('What is the size and growth rate of the target market?', 'The Basics', 'Business Overview', 'textarea', true, ''),
     ('Who are the main competitors, and how is the business differentiated from them?', 'The Basics', 'Business Overview', 'textarea', true, ''),
 

--- a/backend/internal/tests/projects_test.go
+++ b/backend/internal/tests/projects_test.go
@@ -1,20 +1,21 @@
 package tests
 
 import (
-    "context"
-    "encoding/json"
-    "fmt"
-    "io"
-    "net/http"
-    "net/http/httptest"
-    "strings"
-    "testing"
-    "time"
-    "bytes"
+	"KonferCA/SPUR/db"
+	"KonferCA/SPUR/internal/server"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
 
-    "KonferCA/SPUR/db"
-    "KonferCA/SPUR/internal/server"
-    "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 /*
@@ -30,448 +31,476 @@ import (
  * through the project workflows using that test data.
  */
 func TestProjectEndpoints(t *testing.T) {
-    // Setup test environment
-    setupEnv()
-    
-    s, err := server.New()
-    assert.NoError(t, err)
+	// Setup test environment
+	setupEnv()
 
-    // Create test user and get auth token
-    ctx := context.Background()
-    userID, email, password, err := createTestUser(ctx, s)
-    assert.NoError(t, err)
-    t.Logf("Created test user - ID: %s, Email: %s, Password: %s", userID, email, password)
-    defer removeTestUser(ctx, email, s)
+	s, err := server.New()
+	assert.NoError(t, err)
 
-    
-    // Verify the user exists and check their status
-    user, err := s.GetQueries().GetUserByEmail(ctx, email)
-    assert.NoError(t, err, "Should find user in database")
-    t.Logf("User from DB - ID: %s, Email: %s, EmailVerified: %v", user.ID, user.Email, user.EmailVerified)
+	// removing all existing questions that are inserted via migrations
+	// the questions inserted by migrations can change over time so
+	// they are not a reliable way to run tests.
+	_, err = s.DBPool.Exec(context.Background(), "DELETE FROM project_questions;")
+	require.NoError(t, err)
 
-    // Directly verify email in database
-    err = s.GetQueries().UpdateUserEmailVerifiedStatus(ctx, db.UpdateUserEmailVerifiedStatusParams{
-        ID:            userID,
-        EmailVerified: true,
-    })
-    assert.NoError(t, err, "Should update email verification status")
+	// seeding database with sample questions
+	rows, err := s.DBPool.Query(
+		context.Background(),
+		`
+            INSERT INTO project_questions
+            (sub_section_order, question, section, sub_section, required, validations, input_type) VALUES
+            (0, 'Company website', 'Test', 'Sub-Test', true, 'url', 'textinput'),
+            (0, 'What is the unique value proposition?', 'Test', 'Sub-Test', true, 'min=50', 'textinput'),
+            (0, 'What is the core product or service, and what problem does it solve?', 'Test', 'Sub-Test', true, 'min=100', 'textinput')
+            RETURNING id;
+            `,
+	)
+	require.NoError(t, err)
+	testQuestionIds := make([]string, 3)
+	for i := 0; rows.Next(); i++ {
+		var id string
+		err = rows.Scan(&id)
+		require.NoError(t, err)
+		testQuestionIds[i] = id
+	}
+	require.Equal(t, 3, len(testQuestionIds))
 
-    // Verify the update worked
-    user, err = s.GetQueries().GetUserByEmail(ctx, email)
-    assert.NoError(t, err)
-    assert.True(t, user.EmailVerified, "User's email should be verified")
-    t.Logf("User after verification - ID: %s, Email: %s, EmailVerified: %v", user.ID, user.Email, user.EmailVerified)
+	// Create test user and get auth token
+	ctx := context.Background()
+	userID, email, password, err := createTestUser(ctx, s)
+	assert.NoError(t, err)
+	t.Logf("Created test user - ID: %s, Email: %s, Password: %s", userID, email, password)
+	defer removeTestUser(ctx, email, s)
 
-    // Wait a moment to ensure DB updates are complete
-    time.Sleep(100 * time.Millisecond)
+	// Verify the user exists and check their status
+	user, err := s.GetQueries().GetUserByEmail(ctx, email)
+	assert.NoError(t, err, "Should find user in database")
+	t.Logf("User from DB - ID: %s, Email: %s, EmailVerified: %v", user.ID, user.Email, user.EmailVerified)
 
-    // Login
-    loginBody := fmt.Sprintf(`{"email":"%s","password":"%s"}`, email, password)
-    t.Logf("Attempting login with body: %s", loginBody)
-    
-    req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", strings.NewReader(loginBody))
-    req.Header.Set("Content-Type", "application/json")
-    rec := httptest.NewRecorder()
-    s.GetEcho().ServeHTTP(rec, req)
-    
-    if !assert.Equal(t, http.StatusOK, rec.Code, "Login should succeed") {
-        t.Logf("Login response body: %s", rec.Body.String())
-        t.FailNow()
-    }
+	// Directly verify email in database
+	err = s.GetQueries().UpdateUserEmailVerifiedStatus(ctx, db.UpdateUserEmailVerifiedStatusParams{
+		ID:            userID,
+		EmailVerified: true,
+	})
+	assert.NoError(t, err, "Should update email verification status")
 
-    // Parse login response
-    var loginResp map[string]interface{}
-    err = json.NewDecoder(rec.Body).Decode(&loginResp)
-    assert.NoError(t, err, "Should decode login response")
-    
-    accessToken, ok := loginResp["access_token"].(string)
-    assert.True(t, ok, "Response should contain access_token")
-    assert.NotEmpty(t, accessToken, "Access token should not be empty")
+	// Verify the update worked
+	user, err = s.GetQueries().GetUserByEmail(ctx, email)
+	assert.NoError(t, err)
+	assert.True(t, user.EmailVerified, "User's email should be verified")
+	t.Logf("User after verification - ID: %s, Email: %s, EmailVerified: %v", user.ID, user.Email, user.EmailVerified)
 
-    // Create a company for the user
-    companyID, err := createTestCompany(ctx, s, userID)
-    assert.NoError(t, err, "Should create test company")
-    defer removeTestCompany(ctx, companyID, s)
-    t.Logf("Created test company - ID: %s", companyID)
+	// Wait a moment to ensure DB updates are complete
+	time.Sleep(100 * time.Millisecond)
 
-    // Variable to store project ID for subsequent tests
-    var projectID string
+	// Login
+	loginBody := fmt.Sprintf(`{"email":"%s","password":"%s"}`, email, password)
+	t.Logf("Attempting login with body: %s", loginBody)
 
-    t.Run("Create Project", func(t *testing.T) {
-        /*
-         * "Create Project" test verifies:
-         * - Project creation with valid data
-         * - Response contains valid project ID
-         * - Project is associated with correct company
-         */
-        projectBody := fmt.Sprintf(`{
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", strings.NewReader(loginBody))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	s.GetEcho().ServeHTTP(rec, req)
+
+	if !assert.Equal(t, http.StatusOK, rec.Code, "Login should succeed") {
+		t.Logf("Login response body: %s", rec.Body.String())
+		t.FailNow()
+	}
+
+	// Parse login response
+	var loginResp map[string]interface{}
+	err = json.NewDecoder(rec.Body).Decode(&loginResp)
+	assert.NoError(t, err, "Should decode login response")
+
+	accessToken, ok := loginResp["access_token"].(string)
+	assert.True(t, ok, "Response should contain access_token")
+	assert.NotEmpty(t, accessToken, "Access token should not be empty")
+
+	// Create a company for the user
+	companyID, err := createTestCompany(ctx, s, userID)
+	assert.NoError(t, err, "Should create test company")
+	defer removeTestCompany(ctx, companyID, s)
+	t.Logf("Created test company - ID: %s", companyID)
+
+	// Variable to store project ID for subsequent tests
+	var projectID string
+
+	t.Run("Create Project", func(t *testing.T) {
+		/*
+		 * "Create Project" test verifies:
+		 * - Project creation with valid data
+		 * - Response contains valid project ID
+		 * - Project is associated with correct company
+		 */
+		projectBody := fmt.Sprintf(`{
             "company_id": "%s",
             "title": "Test Project",
             "description": "A test project",
             "name": "Test Project"
         }`, companyID)
 
-        req := httptest.NewRequest(http.MethodPost, "/api/v1/project/new", strings.NewReader(projectBody))
-        req.Header.Set("Authorization", "Bearer "+accessToken)
-        req.Header.Set("Content-Type", "application/json")
-        rec := httptest.NewRecorder()
-        s.GetEcho().ServeHTTP(rec, req)
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/project/new", strings.NewReader(projectBody))
+		req.Header.Set("Authorization", "Bearer "+accessToken)
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		s.GetEcho().ServeHTTP(rec, req)
 
-        if !assert.Equal(t, http.StatusOK, rec.Code) {
-            t.Logf("Create project response: %s", rec.Body.String())
-            t.FailNow()
-        }
+		if !assert.Equal(t, http.StatusOK, rec.Code) {
+			t.Logf("Create project response: %s", rec.Body.String())
+			t.FailNow()
+		}
 
-        var resp map[string]interface{}
-        err := json.NewDecoder(rec.Body).Decode(&resp)
-        assert.NoError(t, err)
-        
-        var ok bool
-        projectID, ok = resp["id"].(string)
-        assert.True(t, ok, "Response should contain project ID")
-        assert.NotEmpty(t, projectID, "Project ID should not be empty")
-    })
+		var resp map[string]interface{}
+		err := json.NewDecoder(rec.Body).Decode(&resp)
+		assert.NoError(t, err)
 
-    t.Run("List Projects", func(t *testing.T) {
-        /*
-         * "List Projects" test verifies:
-         * - Endpoint returns 200 OK
-         * - User can see their projects
-         */
-        req := httptest.NewRequest(http.MethodGet, "/api/v1/project", nil)
-        req.Header.Set("Authorization", "Bearer "+accessToken)
-        rec := httptest.NewRecorder()
-        s.GetEcho().ServeHTTP(rec, req)
+		var ok bool
+		projectID, ok = resp["id"].(string)
+		assert.True(t, ok, "Response should contain project ID")
+		assert.NotEmpty(t, projectID, "Project ID should not be empty")
+	})
 
-        assert.Equal(t, http.StatusOK, rec.Code)
-    })
+	t.Run("List Projects", func(t *testing.T) {
+		/*
+		 * "List Projects" test verifies:
+		 * - Endpoint returns 200 OK
+		 * - User can see their projects
+		 */
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/project", nil)
+		req.Header.Set("Authorization", "Bearer "+accessToken)
+		rec := httptest.NewRecorder()
+		s.GetEcho().ServeHTTP(rec, req)
 
-    t.Run("Get Project", func(t *testing.T) {
-        /*
-         * "Get Project" test verifies:
-         * - Single project retrieval works
-         * - Project details are accessible
-         */
-        path := fmt.Sprintf("/api/v1/project/%s", projectID)
-        t.Logf("Getting project at path: %s", path)
-        
-        req := httptest.NewRequest(http.MethodGet, path, nil)
-        req.Header.Set("Authorization", "Bearer "+accessToken)
-        rec := httptest.NewRecorder()
-        s.GetEcho().ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusOK, rec.Code)
+	})
 
-        if !assert.Equal(t, http.StatusOK, rec.Code) {
-            t.Logf("Get project response: %s", rec.Body.String())
-        }
-    })
+	t.Run("Get Project", func(t *testing.T) {
+		/*
+		 * "Get Project" test verifies:
+		 * - Single project retrieval works
+		 * - Project details are accessible
+		 */
+		path := fmt.Sprintf("/api/v1/project/%s", projectID)
+		t.Logf("Getting project at path: %s", path)
 
-    t.Run("Submit Project", func(t *testing.T) {
-        /*
-         * "Submit Project" test verifies the complete submission flow:
-         * 1. Creates initial project
-         * 2. Creates answers for required questions
-         * 3. Updates each answer with valid data
-         * 4. Submits the completed project
-         * 5. Verifies project status changes to 'pending'
-         */
-        // First get the available questions
-        req := httptest.NewRequest(http.MethodGet, "/api/v1/project/questions", nil)
-        req.Header.Set("Authorization", "Bearer "+accessToken)
-        rec := httptest.NewRecorder()
-        s.GetEcho().ServeHTTP(rec, req)
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		req.Header.Set("Authorization", "Bearer "+accessToken)
+		rec := httptest.NewRecorder()
+		s.GetEcho().ServeHTTP(rec, req)
 
-        if !assert.Equal(t, http.StatusOK, rec.Code) {
-            t.Logf("Get questions response: %s", rec.Body.String())
-            t.FailNow()
-        }
+		if !assert.Equal(t, http.StatusOK, rec.Code) {
+			t.Logf("Get project response: %s", rec.Body.String())
+		}
+	})
 
-        var questionsResp struct {
-            Questions []struct {
-                ID       string `json:"id"`
-                Question string `json:"question"`
-                Section  string `json:"section"`
-            } `json:"questions"`
-        }
-        err := json.NewDecoder(rec.Body).Decode(&questionsResp)
-        assert.NoError(t, err)
-        assert.NotEmpty(t, questionsResp.Questions, "Should have questions available")
+	t.Run("Submit Project", func(t *testing.T) {
+		/*
+		 * "Submit Project" test verifies the complete submission flow:
+		 * 1. Creates initial project
+		 * 2. Creates answers for required questions
+		 * 3. Updates each answer with valid data
+		 * 4. Submits the completed project
+		 * 5. Verifies project status changes to 'pending'
+		 */
+		// First get the available questions
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/project/questions", nil)
+		req.Header.Set("Authorization", "Bearer "+accessToken)
+		rec := httptest.NewRecorder()
+		s.GetEcho().ServeHTTP(rec, req)
 
-        // Create answers for each question
-        for _, q := range questionsResp.Questions {
-            var answer string
-            switch q.Question {
-            case "Company website":
-                answer = "https://example.com"
-            case "What is the core product or service, and what problem does it solve?":
-                answer = "Our product is a revolutionary blockchain-based authentication system that solves critical identity verification issues in the digital age. We provide a secure, scalable solution that eliminates fraud while maintaining user privacy and compliance with international regulations."
-            case "What is the unique value proposition?":
-                answer = "Our product is a revolutionary blockchain-based authentication system that solves critical identity verification issues in the digital age. We provide a secure, scalable solution that eliminates fraud while maintaining user privacy and compliance with international regulations."
-            default:
-                continue // Skip non-required questions
-            }
+		if !assert.Equal(t, http.StatusOK, rec.Code) {
+			t.Logf("Get questions response: %s", rec.Body.String())
+			t.FailNow()
+		}
 
-            // Create the answer
-            createBody := map[string]interface{}{
-                "content":     answer,
-                "project_id":  projectID,
-                "question_id": q.ID,
-            }
-            createJSON, err := json.Marshal(createBody)
-            assert.NoError(t, err)
+		var questionsResp struct {
+			Questions []struct {
+				ID       string `json:"id"`
+				Question string `json:"question"`
+				Section  string `json:"section"`
+			} `json:"questions"`
+		}
+		err = json.NewDecoder(rec.Body).Decode(&questionsResp)
+		assert.NoError(t, err)
+		assert.NotEmpty(t, questionsResp.Questions, "Should have questions available")
 
-            createReq := httptest.NewRequest(
-                http.MethodPost, 
-                fmt.Sprintf("/api/v1/project/%s/answers", projectID),
-                bytes.NewReader(createJSON),
-            )
-            createReq.Header.Set("Authorization", "Bearer "+accessToken)
-            createReq.Header.Set("Content-Type", "application/json")
-            createRec := httptest.NewRecorder()
-            s.GetEcho().ServeHTTP(createRec, createReq)
+		// Create answers for each question
+		for _, q := range questionsResp.Questions {
+			var answer string
+			switch q.Question {
+			case "Company website":
+				answer = "https://example.com"
+			case "What is the core product or service, and what problem does it solve?":
+				answer = "Our product is a revolutionary blockchain-based authentication system that solves critical identity verification issues in the digital age. We provide a secure, scalable solution that eliminates fraud while maintaining user privacy and compliance with international regulations."
+			case "What is the unique value proposition?":
+				answer = "Our product is a revolutionary blockchain-based authentication system that solves critical identity verification issues in the digital age. We provide a secure, scalable solution that eliminates fraud while maintaining user privacy and compliance with international regulations."
+			default:
+				continue // Skip non-required questions
+			}
 
-            if !assert.Equal(t, http.StatusOK, createRec.Code) {
-                t.Logf("Create answer response: %s", createRec.Body.String())
-            }
-        }
+			// Create the answer
+			createBody := map[string]interface{}{
+				"content":     answer,
+				"project_id":  projectID,
+				"question_id": q.ID,
+			}
+			createJSON, err := json.Marshal(createBody)
+			assert.NoError(t, err)
 
-        // Now submit the project
-        submitPath := fmt.Sprintf("/api/v1/project/%s/submit", projectID)
-        req = httptest.NewRequest(http.MethodPost, submitPath, nil)
-        req.Header.Set("Authorization", "Bearer "+accessToken)
-        rec = httptest.NewRecorder()
-        s.GetEcho().ServeHTTP(rec, req)
+			createReq := httptest.NewRequest(
+				http.MethodPost,
+				fmt.Sprintf("/api/v1/project/%s/answers", projectID),
+				bytes.NewReader(createJSON),
+			)
+			createReq.Header.Set("Authorization", "Bearer "+accessToken)
+			createReq.Header.Set("Content-Type", "application/json")
+			createRec := httptest.NewRecorder()
+			s.GetEcho().ServeHTTP(createRec, createReq)
 
-        t.Logf("Submit response: %s", rec.Body.String())
+			if !assert.Equal(t, http.StatusOK, createRec.Code) {
+				t.Logf("Create answer response: %s", createRec.Body.String())
+			}
+		}
 
-        if !assert.Equal(t, http.StatusOK, rec.Code) {
-            t.Logf("Submit project response: %s", rec.Body.String())
-        }
+		// Now submit the project
+		submitPath := fmt.Sprintf("/api/v1/project/%s/submit", projectID)
+		req = httptest.NewRequest(http.MethodPost, submitPath, nil)
+		req.Header.Set("Authorization", "Bearer "+accessToken)
+		rec = httptest.NewRecorder()
+		s.GetEcho().ServeHTTP(rec, req)
 
-        var submitResp struct {
-            Message string `json:"message"`
-            Status  string `json:"status"`
-        }
-        err = json.NewDecoder(rec.Body).Decode(&submitResp)
-        assert.NoError(t, err)
-        assert.Equal(t, "Project submitted successfully", submitResp.Message)
-        assert.Equal(t, "pending", submitResp.Status)
-    })
+		t.Logf("Submit response: %s", rec.Body.String())
 
-    /*
-     * "Error Cases" test suite verifies proper error handling:
-     * - Invalid project ID returns 404
-     * - Unauthorized access returns 401
-     * - Short answers fail validation
-     * - Invalid URL format fails validation
-     * 
-     * Uses real question/answer IDs from the project to ensure
-     * accurate validation testing.
-     */
-    t.Run("Error Cases", func(t *testing.T) {
-        // First get the questions/answers to get real IDs
-        path := fmt.Sprintf("/api/v1/project/%s/answers", projectID)
-        req := httptest.NewRequest(http.MethodGet, path, nil)
-        req.Header.Set("Authorization", "Bearer "+accessToken)
-        rec := httptest.NewRecorder()
-        s.GetEcho().ServeHTTP(rec, req)
+		if !assert.Equal(t, http.StatusOK, rec.Code) {
+			t.Logf("Submit project response: %s", rec.Body.String())
+		}
 
-        var answersResp struct {
-            Answers []struct {
-                ID         string `json:"id"`
-                QuestionID string `json:"question_id"`
-                Question   string `json:"question"`
-            } `json:"answers"`
-        }
-        err := json.NewDecoder(rec.Body).Decode(&answersResp)
-        assert.NoError(t, err)
+		var submitResp struct {
+			Message string `json:"message"`
+			Status  string `json:"status"`
+		}
+		err = json.NewDecoder(rec.Body).Decode(&submitResp)
+		assert.NoError(t, err)
+		assert.Equal(t, "Project submitted successfully", submitResp.Message)
+		assert.Equal(t, "pending", submitResp.Status)
+	})
 
-        // Find answer ID for the core product question (which has min length validation)
-        var coreQuestionAnswerID string
-        var websiteQuestionAnswerID string
-        for _, a := range answersResp.Answers {
-            if strings.Contains(a.Question, "core product") {
-                coreQuestionAnswerID = a.ID
-            }
-            if strings.Contains(a.Question, "website") {
-                websiteQuestionAnswerID = a.ID
-            }
-        }
+	/*
+	 * "Error Cases" test suite verifies proper error handling:
+	 * - Invalid project ID returns 404
+	 * - Unauthorized access returns 401
+	 * - Short answers fail validation
+	 * - Invalid URL format fails validation
+	 *
+	 * Uses real question/answer IDs from the project to ensure
+	 * accurate validation testing.
+	 */
+	t.Run("Error Cases", func(t *testing.T) {
+		// First get the questions/answers to get real IDs
+		path := fmt.Sprintf("/api/v1/project/%s/answers", projectID)
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		req.Header.Set("Authorization", "Bearer "+accessToken)
+		rec := httptest.NewRecorder()
+		s.GetEcho().ServeHTTP(rec, req)
 
-        // Ensure we found the questions we need
-        assert.NotEmpty(t, coreQuestionAnswerID, "Should find core product question")
-        assert.NotEmpty(t, websiteQuestionAnswerID, "Should find website question")
+		var answersResp struct {
+			Answers []struct {
+				ID         string `json:"id"`
+				QuestionID string `json:"question_id"`
+				Question   string `json:"question"`
+			} `json:"answers"`
+		}
+		err := json.NewDecoder(rec.Body).Decode(&answersResp)
+		assert.NoError(t, err)
 
-        tests := []struct {
-            name           string
-            method        string
-            path          string
-            body          string
-            setupAuth     func(*http.Request)
-            expectedCode  int
-            expectedError string
-        }{
-            {
-                name:   "Get Invalid Project",
-                method: http.MethodGet,
-                path:   "/api/v1/project/invalid-id",
-                setupAuth: func(req *http.Request) {
-                    req.Header.Set("Authorization", "Bearer "+accessToken)
-                },
-                expectedCode:  http.StatusNotFound,
-                expectedError: "Project not found",
-            },
-            {
-                name:   "Unauthorized Access",
-                method: http.MethodGet,
-                path:   fmt.Sprintf("/api/v1/project/%s", projectID),
-                setupAuth: func(req *http.Request) {
-                    // No auth header
-                },
-                expectedCode:  http.StatusUnauthorized,
-                expectedError: "missing authorization header",
-            },
-            {
-                name:   "Invalid Answer Length",
-                method: http.MethodPatch,
-                path:   fmt.Sprintf("/api/v1/project/%s/answers", projectID),
-                body:   fmt.Sprintf(`{"content": "too short", "answer_id": "%s"}`, coreQuestionAnswerID),
-                setupAuth: func(req *http.Request) {
-                    req.Header.Set("Authorization", "Bearer "+accessToken)
-                },
-                expectedCode:  http.StatusBadRequest,
-                expectedError: "Must be at least",
-            },
-            {
-                name:   "Invalid URL Format",
-                method: http.MethodPatch,
-                path:   fmt.Sprintf("/api/v1/project/%s/answers", projectID),
-                body:   fmt.Sprintf(`{"content": "not-a-url", "answer_id": "%s"}`, websiteQuestionAnswerID),
-                setupAuth: func(req *http.Request) {
-                    req.Header.Set("Authorization", "Bearer "+accessToken)
-                },
-                expectedCode:  http.StatusBadRequest,
-                expectedError: "Must be a valid URL",
-            },
-            {
-                name:   "Create Answer Without Question",
-                method: http.MethodPost,
-                path:   fmt.Sprintf("/api/v1/project/%s/answers", projectID),
-                body:   `{"content": "some answer"}`, // Missing question_id
-                setupAuth: func(req *http.Request) {
-                    req.Header.Set("Authorization", "Bearer "+accessToken)
-                },
-                expectedCode:  http.StatusBadRequest,
-                expectedError: "Question ID is required",
-            },
-            {
-                name:   "Create Answer For Invalid Question",
-                method: http.MethodPost,
-                path:   fmt.Sprintf("/api/v1/project/%s/answers", projectID),
-                body:   `{"content": "some answer", "question_id": "invalid-id"}`,
-                setupAuth: func(req *http.Request) {
-                    req.Header.Set("Authorization", "Bearer "+accessToken)
-                },
-                expectedCode:  http.StatusNotFound,
-                expectedError: "Question not found",
-            },
-        }
+		// Find answer ID for the core product question (which has min length validation)
+		var coreQuestionAnswerID string
+		var websiteQuestionAnswerID string
+		for _, a := range answersResp.Answers {
+			if strings.Contains(a.Question, "core product") {
+				coreQuestionAnswerID = a.ID
+			}
+			if strings.Contains(a.Question, "website") {
+				websiteQuestionAnswerID = a.ID
+			}
+		}
 
-        for _, tc := range tests {
-            t.Run(tc.name, func(t *testing.T) {
-                var body io.Reader
-                if tc.body != "" {
-                    body = strings.NewReader(tc.body)
-                }
-                
-                req := httptest.NewRequest(tc.method, tc.path, body)
-                tc.setupAuth(req)
-                if tc.body != "" {
-                    req.Header.Set("Content-Type", "application/json")
-                }
-                rec := httptest.NewRecorder()
+		// Ensure we found the questions we need
+		assert.NotEmpty(t, coreQuestionAnswerID, "Should find core product question")
+		assert.NotEmpty(t, websiteQuestionAnswerID, "Should find website question")
 
-                s.GetEcho().ServeHTTP(rec, req)
+		tests := []struct {
+			name          string
+			method        string
+			path          string
+			body          string
+			setupAuth     func(*http.Request)
+			expectedCode  int
+			expectedError string
+		}{
+			{
+				name:   "Get Invalid Project",
+				method: http.MethodGet,
+				path:   "/api/v1/project/invalid-id",
+				setupAuth: func(req *http.Request) {
+					req.Header.Set("Authorization", "Bearer "+accessToken)
+				},
+				expectedCode:  http.StatusNotFound,
+				expectedError: "Project not found",
+			},
+			{
+				name:   "Unauthorized Access",
+				method: http.MethodGet,
+				path:   fmt.Sprintf("/api/v1/project/%s", projectID),
+				setupAuth: func(req *http.Request) {
+					// No auth header
+				},
+				expectedCode:  http.StatusUnauthorized,
+				expectedError: "missing authorization header",
+			},
+			{
+				name:   "Invalid Answer Length",
+				method: http.MethodPatch,
+				path:   fmt.Sprintf("/api/v1/project/%s/answers", projectID),
+				body:   fmt.Sprintf(`{"content": "too short", "answer_id": "%s"}`, coreQuestionAnswerID),
+				setupAuth: func(req *http.Request) {
+					req.Header.Set("Authorization", "Bearer "+accessToken)
+				},
+				expectedCode:  http.StatusBadRequest,
+				expectedError: "Must be at least",
+			},
+			{
+				name:   "Invalid URL Format",
+				method: http.MethodPatch,
+				path:   fmt.Sprintf("/api/v1/project/%s/answers", projectID),
+				body:   fmt.Sprintf(`{"content": "not-a-url", "answer_id": "%s"}`, websiteQuestionAnswerID),
+				setupAuth: func(req *http.Request) {
+					req.Header.Set("Authorization", "Bearer "+accessToken)
+				},
+				expectedCode:  http.StatusBadRequest,
+				expectedError: "Must be a valid URL",
+			},
+			{
+				name:   "Create Answer Without Question",
+				method: http.MethodPost,
+				path:   fmt.Sprintf("/api/v1/project/%s/answers", projectID),
+				body:   `{"content": "some answer"}`, // Missing question_id
+				setupAuth: func(req *http.Request) {
+					req.Header.Set("Authorization", "Bearer "+accessToken)
+				},
+				expectedCode:  http.StatusBadRequest,
+				expectedError: "Question ID is required",
+			},
+			{
+				name:   "Create Answer For Invalid Question",
+				method: http.MethodPost,
+				path:   fmt.Sprintf("/api/v1/project/%s/answers", projectID),
+				body:   `{"content": "some answer", "question_id": "invalid-id"}`,
+				setupAuth: func(req *http.Request) {
+					req.Header.Set("Authorization", "Bearer "+accessToken)
+				},
+				expectedCode:  http.StatusNotFound,
+				expectedError: "Question not found",
+			},
+		}
 
-                assert.Equal(t, tc.expectedCode, rec.Code)
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				var body io.Reader
+				if tc.body != "" {
+					body = strings.NewReader(tc.body)
+				}
 
-                var errResp struct {
-                    Message string `json:"message"`
-                    ValidationErrors []struct {
-                        Question string `json:"question"`
-                        Message  string `json:"message"`
-                    } `json:"validation_errors"`
-                }
-                err := json.NewDecoder(rec.Body).Decode(&errResp)
-                assert.NoError(t, err)
+				req := httptest.NewRequest(tc.method, tc.path, body)
+				tc.setupAuth(req)
+				if tc.body != "" {
+					req.Header.Set("Content-Type", "application/json")
+				}
+				rec := httptest.NewRecorder()
 
-                if len(errResp.ValidationErrors) > 0 {
-                    assert.Contains(t, errResp.ValidationErrors[0].Message, tc.expectedError)
-                } else {
-                    assert.Contains(t, errResp.Message, tc.expectedError)
-                }
-            })
-        }
-    })
+				s.GetEcho().ServeHTTP(rec, req)
 
-    t.Run("Comment Resolution", func(t *testing.T) {
-        // Create an admin user for testing
-        _, adminEmail, adminPassword, err := createTestAdminUser(ctx, s)
-        assert.NoError(t, err)
-        defer removeTestUser(ctx, adminEmail, s)
+				assert.Equal(t, tc.expectedCode, rec.Code)
 
-        // Login as admin
-        adminToken := loginAndGetToken(t, s, adminEmail, adminPassword)
+				var errResp struct {
+					Message          string `json:"message"`
+					ValidationErrors []struct {
+						Question string `json:"question"`
+						Message  string `json:"message"`
+					} `json:"validation_errors"`
+				}
+				err := json.NewDecoder(rec.Body).Decode(&errResp)
+				assert.NoError(t, err)
 
-        // Create a test comment first
-        commentBody := fmt.Sprintf(`{
+				if len(errResp.ValidationErrors) > 0 {
+					assert.Contains(t, errResp.ValidationErrors[0].Message, tc.expectedError)
+				} else {
+					assert.Contains(t, errResp.Message, tc.expectedError)
+				}
+			})
+		}
+	})
+
+	t.Run("Comment Resolution", func(t *testing.T) {
+		// Create an admin user for testing
+		_, adminEmail, adminPassword, err := createTestAdminUser(ctx, s)
+		assert.NoError(t, err)
+		defer removeTestUser(ctx, adminEmail, s)
+
+		// Login as admin
+		adminToken := loginAndGetToken(t, s, adminEmail, adminPassword)
+
+		// Create a test comment first
+		commentBody := fmt.Sprintf(`{
             "comment": "Test comment",
             "target_id": "%s"
         }`, projectID)
 
-        req := httptest.NewRequest(http.MethodPost, 
-            fmt.Sprintf("/api/v1/project/%s/comments", projectID),
-            strings.NewReader(commentBody))
-        req.Header.Set("Authorization", "Bearer "+adminToken)
-        req.Header.Set("Content-Type", "application/json")
-        rec := httptest.NewRecorder()
-        s.GetEcho().ServeHTTP(rec, req)
+		req := httptest.NewRequest(http.MethodPost,
+			fmt.Sprintf("/api/v1/project/%s/comments", projectID),
+			strings.NewReader(commentBody))
+		req.Header.Set("Authorization", "Bearer "+adminToken)
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		s.GetEcho().ServeHTTP(rec, req)
 
-        assert.Equal(t, http.StatusCreated, rec.Code)
+		assert.Equal(t, http.StatusCreated, rec.Code)
 
-        var commentResp map[string]interface{}
-        err = json.NewDecoder(rec.Body).Decode(&commentResp)
-        assert.NoError(t, err)
+		var commentResp map[string]interface{}
+		err = json.NewDecoder(rec.Body).Decode(&commentResp)
+		assert.NoError(t, err)
 
-        commentID := commentResp["id"].(string)
+		commentID := commentResp["id"].(string)
 
-        // Test resolving the comment
-        req = httptest.NewRequest(http.MethodPost,
-            fmt.Sprintf("/api/v1/project/%s/comments/%s/resolve", projectID, commentID),
-            nil)
-        req.Header.Set("Authorization", "Bearer "+adminToken)
-        rec = httptest.NewRecorder()
-        s.GetEcho().ServeHTTP(rec, req)
+		// Test resolving the comment
+		req = httptest.NewRequest(http.MethodPost,
+			fmt.Sprintf("/api/v1/project/%s/comments/%s/resolve", projectID, commentID),
+			nil)
+		req.Header.Set("Authorization", "Bearer "+adminToken)
+		rec = httptest.NewRecorder()
+		s.GetEcho().ServeHTTP(rec, req)
 
-        assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Equal(t, http.StatusOK, rec.Code)
 
-        // Test unresolving the comment
-        req = httptest.NewRequest(http.MethodPost,
-            fmt.Sprintf("/api/v1/project/%s/comments/%s/unresolve", projectID, commentID),
-            nil)
-        req.Header.Set("Authorization", "Bearer "+adminToken)
-        rec = httptest.NewRecorder()
-        s.GetEcho().ServeHTTP(rec, req)
+		// Test unresolving the comment
+		req = httptest.NewRequest(http.MethodPost,
+			fmt.Sprintf("/api/v1/project/%s/comments/%s/unresolve", projectID, commentID),
+			nil)
+		req.Header.Set("Authorization", "Bearer "+adminToken)
+		rec = httptest.NewRecorder()
+		s.GetEcho().ServeHTTP(rec, req)
 
-        assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Equal(t, http.StatusOK, rec.Code)
 
-        // Test non-admin cannot resolve/unresolve
-        req = httptest.NewRequest(http.MethodPost,
-            fmt.Sprintf("/api/v1/project/%s/comments/%s/resolve", projectID, commentID),
-            nil)
-        req.Header.Set("Authorization", "Bearer "+accessToken)
-        rec = httptest.NewRecorder()
-        s.GetEcho().ServeHTTP(rec, req)
+		// Test non-admin cannot resolve/unresolve
+		req = httptest.NewRequest(http.MethodPost,
+			fmt.Sprintf("/api/v1/project/%s/comments/%s/resolve", projectID, commentID),
+			nil)
+		req.Header.Set("Authorization", "Bearer "+accessToken)
+		rec = httptest.NewRecorder()
+		s.GetEcho().ServeHTTP(rec, req)
 
-        assert.Equal(t, http.StatusForbidden, rec.Code)
-    })
+		assert.Equal(t, http.StatusForbidden, rec.Code)
+	})
 }
+


### PR DESCRIPTION
## Description
All the questions from Notion have been added.

Explanation of new columns added to the `project_questions` table.

`sub_section_order` is the order for the questions to be rendered inside a sub section.

`input_type` is not an enum because of the need to allow multiple types for one question. Such as allowing users to input a URL to a google drive with documents or just uploading files. So having a varchar which allows the syntax `A|B` would make more sense and it would be more flexible.

`options` is a nullable column which contains the options for input types `select`, `checkbox`, `radio`.

Possible improvements is to store the order of sections too and these can be in a separate table or just defined in the frontend.

## Linked Issues
- Closes #189 

## Testing
- Migrations are ran in test action

## Checklist
Before opening this PR, make sure the PR:
- [x] Has an **assignee or group of assignees**.
- [x] Has a **reviewer or a group of reviewers**.
- [x] Is **labelled properly**.
- [x] Has the **SPUR project assigned to it**.
- [x] Has an **assigned milestone**.

Additionally, make sure that:
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.