### PR TITLE
Emit json tags for sqlc generated structs

### DIFF
--- a/backend/db/companies.sql.go
+++ b/backend/db/companies.sql.go
@@ -22,10 +22,10 @@ RETURNING id, owner_id, name, wallet_address, linkedin_url, created_at, updated_
 `
 
 type CreateCompanyParams struct {
-	OwnerID       string
-	Name          string
-	WalletAddress *string
-	LinkedinUrl   string
+	OwnerID       string  `json:"owner_id"`
+	Name          string  `json:"name"`
+	WalletAddress *string `json:"wallet_address"`
+	LinkedinUrl   string  `json:"linkedin_url"`
 }
 
 func (q *Queries) CreateCompany(ctx context.Context, arg CreateCompanyParams) (Company, error) {
@@ -104,9 +104,9 @@ WHERE (owner_id = $1 OR $2 = 'admin') AND id = $3
 `
 
 type GetCompanyWithAuthParams struct {
-	OwnerID string
-	Column2 interface{}
-	ID      string
+	OwnerID string      `json:"owner_id"`
+	Column2 interface{} `json:"column_2"`
+	ID      string      `json:"id"`
 }
 
 func (q *Queries) GetCompanyWithAuth(ctx context.Context, arg GetCompanyWithAuthParams) (Company, error) {
@@ -170,10 +170,10 @@ RETURNING id, owner_id, name, wallet_address, linkedin_url, created_at, updated_
 `
 
 type UpdateCompanyParams struct {
-	ID            string
-	Name          string
-	WalletAddress *string
-	LinkedinUrl   string
+	ID            string  `json:"id"`
+	Name          string  `json:"name"`
+	WalletAddress *string `json:"wallet_address"`
+	LinkedinUrl   string  `json:"linkedin_url"`
 }
 
 func (q *Queries) UpdateCompany(ctx context.Context, arg UpdateCompanyParams) (Company, error) {

--- a/backend/db/email_tokens.sql.go
+++ b/backend/db/email_tokens.sql.go
@@ -44,8 +44,8 @@ VALUES ($1, $2) RETURNING id
 `
 
 type NewVerifyEmailTokenParams struct {
-	UserID    string
-	ExpiresAt int64
+	UserID    string `json:"user_id"`
+	ExpiresAt int64  `json:"expires_at"`
 }
 
 func (q *Queries) NewVerifyEmailToken(ctx context.Context, arg NewVerifyEmailTokenParams) (string, error) {

--- a/backend/db/models.go
+++ b/backend/db/models.go
@@ -34,8 +34,8 @@ func (e *ProjectStatus) Scan(src interface{}) error {
 }
 
 type NullProjectStatus struct {
-	ProjectStatus ProjectStatus
-	Valid         bool // Valid is true if ProjectStatus is not NULL
+	ProjectStatus ProjectStatus `json:"project_status"`
+	Valid         bool          `json:"valid"` // Valid is true if ProjectStatus is not NULL
 }
 
 // Scan implements the Scanner interface.
@@ -99,8 +99,8 @@ func (e *UserRole) Scan(src interface{}) error {
 }
 
 type NullUserRole struct {
-	UserRole UserRole
-	Valid    bool // Valid is true if UserRole is not NULL
+	UserRole UserRole `json:"user_role"`
+	Valid    bool     `json:"valid"` // Valid is true if UserRole is not NULL
 }
 
 // Scan implements the Scanner interface.
@@ -140,102 +140,106 @@ func AllUserRoleValues() []UserRole {
 }
 
 type Company struct {
-	ID            string
-	OwnerID       string
-	Name          string
-	WalletAddress *string
-	LinkedinUrl   string
-	CreatedAt     int64
-	UpdatedAt     int64
+	ID            string  `json:"id"`
+	OwnerID       string  `json:"owner_id"`
+	Name          string  `json:"name"`
+	WalletAddress *string `json:"wallet_address"`
+	LinkedinUrl   string  `json:"linkedin_url"`
+	CreatedAt     int64   `json:"created_at"`
+	UpdatedAt     int64   `json:"updated_at"`
 }
 
 type Project struct {
-	ID          string
-	CompanyID   string
-	Title       string
-	Description *string
-	Status      ProjectStatus
-	CreatedAt   int64
-	UpdatedAt   int64
+	ID          string        `json:"id"`
+	CompanyID   string        `json:"company_id"`
+	Title       string        `json:"title"`
+	Description *string       `json:"description"`
+	Status      ProjectStatus `json:"status"`
+	CreatedAt   int64         `json:"created_at"`
+	UpdatedAt   int64         `json:"updated_at"`
 }
 
 type ProjectAnswer struct {
-	ID         string
-	ProjectID  string
-	QuestionID string
-	Answer     string
-	CreatedAt  int64
-	UpdatedAt  int64
+	ID         string `json:"id"`
+	ProjectID  string `json:"project_id"`
+	QuestionID string `json:"question_id"`
+	Answer     string `json:"answer"`
+	CreatedAt  int64  `json:"created_at"`
+	UpdatedAt  int64  `json:"updated_at"`
 }
 
 type ProjectComment struct {
-	ID          string
-	ProjectID   string
-	TargetID    string
-	Comment     string
-	CommenterID string
-	Resolved    bool
-	CreatedAt   int64
-	UpdatedAt   int64
+	ID          string `json:"id"`
+	ProjectID   string `json:"project_id"`
+	TargetID    string `json:"target_id"`
+	Comment     string `json:"comment"`
+	CommenterID string `json:"commenter_id"`
+	Resolved    bool   `json:"resolved"`
+	CreatedAt   int64  `json:"created_at"`
+	UpdatedAt   int64  `json:"updated_at"`
 }
 
 type ProjectDocument struct {
-	ID        string
-	ProjectID string
-	Name      string
-	Url       string
-	Section   string
-	CreatedAt int64
-	UpdatedAt int64
+	ID        string `json:"id"`
+	ProjectID string `json:"project_id"`
+	Name      string `json:"name"`
+	Url       string `json:"url"`
+	Section   string `json:"section"`
+	CreatedAt int64  `json:"created_at"`
+	UpdatedAt int64  `json:"updated_at"`
 }
 
 type ProjectQuestion struct {
-	ID          string
-	Question    string
-	Section     string
-	Required    bool
-	Validations *string
-	CreatedAt   int64
-	UpdatedAt   int64
+	ID              string   `json:"id"`
+	Question        string   `json:"question"`
+	Section         string   `json:"section"`
+	Required        bool     `json:"required"`
+	Validations     *string  `json:"validations"`
+	SubSectionOrder int32    `json:"sub_section_order"`
+	CreatedAt       int64    `json:"created_at"`
+	UpdatedAt       int64    `json:"updated_at"`
+	SubSection      string   `json:"sub_section"`
+	InputType       string   `json:"input_type"`
+	Options         []string `json:"options"`
 }
 
 type TeamMember struct {
-	ID             string
-	CompanyID      string
-	FirstName      string
-	LastName       string
-	Title          string
-	Bio            string
-	LinkedinUrl    string
-	IsAccountOwner bool
-	CreatedAt      int64
-	UpdatedAt      int64
+	ID             string `json:"id"`
+	CompanyID      string `json:"company_id"`
+	FirstName      string `json:"first_name"`
+	LastName       string `json:"last_name"`
+	Title          string `json:"title"`
+	Bio            string `json:"bio"`
+	LinkedinUrl    string `json:"linkedin_url"`
+	IsAccountOwner bool   `json:"is_account_owner"`
+	CreatedAt      int64  `json:"created_at"`
+	UpdatedAt      int64  `json:"updated_at"`
 }
 
 type Transaction struct {
-	ID          string
-	ProjectID   string
-	CompanyID   string
-	TxHash      string
-	FromAddress string
-	ToAddress   string
-	ValueAmount pgtype.Numeric
+	ID          string         `json:"id"`
+	ProjectID   string         `json:"project_id"`
+	CompanyID   string         `json:"company_id"`
+	TxHash      string         `json:"tx_hash"`
+	FromAddress string         `json:"from_address"`
+	ToAddress   string         `json:"to_address"`
+	ValueAmount pgtype.Numeric `json:"value_amount"`
 }
 
 type User struct {
-	ID            string
-	Email         string
-	Password      string
-	Role          UserRole
-	EmailVerified bool
-	CreatedAt     int64
-	UpdatedAt     int64
-	TokenSalt     []byte
+	ID            string   `json:"id"`
+	Email         string   `json:"email"`
+	Password      string   `json:"password"`
+	Role          UserRole `json:"role"`
+	EmailVerified bool     `json:"email_verified"`
+	CreatedAt     int64    `json:"created_at"`
+	UpdatedAt     int64    `json:"updated_at"`
+	TokenSalt     []byte   `json:"token_salt"`
 }
 
 type VerifyEmailToken struct {
-	ID        string
-	UserID    string
-	CreatedAt int64
-	ExpiresAt int64
+	ID        string `json:"id"`
+	UserID    string `json:"user_id"`
+	CreatedAt int64  `json:"created_at"`
+	ExpiresAt int64  `json:"expires_at"`
 }

--- a/backend/db/projects.sql.go
+++ b/backend/db/projects.sql.go
@@ -23,12 +23,12 @@ INSERT INTO projects (
 `
 
 type CreateProjectParams struct {
-	CompanyID   string
-	Title       string
-	Description *string
-	Status      ProjectStatus
-	CreatedAt   int64
-	UpdatedAt   int64
+	CompanyID   string        `json:"company_id"`
+	Title       string        `json:"title"`
+	Description *string       `json:"description"`
+	Status      ProjectStatus `json:"status"`
+	CreatedAt   int64         `json:"created_at"`
+	UpdatedAt   int64         `json:"updated_at"`
 }
 
 func (q *Queries) CreateProject(ctx context.Context, arg CreateProjectParams) (Project, error) {
@@ -66,9 +66,9 @@ INSERT INTO project_answers (
 `
 
 type CreateProjectAnswerParams struct {
-	ProjectID  string
-	QuestionID string
-	Answer     string
+	ProjectID  string `json:"project_id"`
+	QuestionID string `json:"question_id"`
+	Answer     string `json:"answer"`
 }
 
 func (q *Queries) CreateProjectAnswer(ctx context.Context, arg CreateProjectAnswerParams) (ProjectAnswer, error) {
@@ -138,10 +138,10 @@ INSERT INTO project_comments (
 `
 
 type CreateProjectCommentParams struct {
-	ProjectID   string
-	TargetID    string
-	Comment     string
-	CommenterID string
+	ProjectID   string `json:"project_id"`
+	TargetID    string `json:"target_id"`
+	Comment     string `json:"comment"`
+	CommenterID string `json:"commenter_id"`
 }
 
 func (q *Queries) CreateProjectComment(ctx context.Context, arg CreateProjectCommentParams) (ProjectComment, error) {
@@ -186,10 +186,10 @@ INSERT INTO project_documents (
 `
 
 type CreateProjectDocumentParams struct {
-	ProjectID string
-	Name      string
-	Url       string
-	Section   string
+	ProjectID string `json:"project_id"`
+	Name      string `json:"name"`
+	Url       string `json:"url"`
+	Section   string `json:"section"`
 }
 
 func (q *Queries) CreateProjectDocument(ctx context.Context, arg CreateProjectDocumentParams) (ProjectDocument, error) {
@@ -235,9 +235,9 @@ RETURNING id
 `
 
 type DeleteProjectDocumentParams struct {
-	ID        string
-	ProjectID string
-	CompanyID string
+	ID        string `json:"id"`
+	ProjectID string `json:"project_id"`
+	CompanyID string `json:"company_id"`
 }
 
 func (q *Queries) DeleteProjectDocument(ctx context.Context, arg DeleteProjectDocumentParams) (string, error) {
@@ -282,11 +282,11 @@ ORDER BY pq.section, pq.id
 `
 
 type GetProjectAnswersRow struct {
-	AnswerID   string
-	Answer     string
-	QuestionID string
-	Question   string
-	Section    string
+	AnswerID   string `json:"answer_id"`
+	Answer     string `json:"answer"`
+	QuestionID string `json:"question_id"`
+	Question   string `json:"question"`
+	Section    string `json:"section"`
 }
 
 func (q *Queries) GetProjectAnswers(ctx context.Context, projectID string) ([]GetProjectAnswersRow, error) {
@@ -322,8 +322,8 @@ LIMIT 1
 `
 
 type GetProjectByIDParams struct {
-	ID        string
-	CompanyID string
+	ID        string `json:"id"`
+	CompanyID string `json:"company_id"`
 }
 
 func (q *Queries) GetProjectByID(ctx context.Context, arg GetProjectByIDParams) (Project, error) {
@@ -369,8 +369,8 @@ LIMIT 1
 `
 
 type GetProjectCommentParams struct {
-	ID        string
-	ProjectID string
+	ID        string `json:"id"`
+	ProjectID string `json:"project_id"`
 }
 
 func (q *Queries) GetProjectComment(ctx context.Context, arg GetProjectCommentParams) (ProjectComment, error) {
@@ -433,9 +433,9 @@ AND projects.company_id = $3
 `
 
 type GetProjectDocumentParams struct {
-	ID        string
-	ProjectID string
-	CompanyID string
+	ID        string `json:"id"`
+	ProjectID string `json:"project_id"`
+	CompanyID string `json:"company_id"`
 }
 
 func (q *Queries) GetProjectDocument(ctx context.Context, arg GetProjectDocumentParams) (ProjectDocument, error) {
@@ -488,7 +488,7 @@ func (q *Queries) GetProjectDocuments(ctx context.Context, projectID string) ([]
 }
 
 const getProjectQuestion = `-- name: GetProjectQuestion :one
-SELECT id, question, section, required, validations, created_at, updated_at FROM project_questions 
+SELECT id, question, section, required, validations, sub_section_order, created_at, updated_at, sub_section, input_type, options FROM project_questions 
 WHERE id = $1 
 LIMIT 1
 `
@@ -502,8 +502,12 @@ func (q *Queries) GetProjectQuestion(ctx context.Context, id string) (ProjectQue
 		&i.Section,
 		&i.Required,
 		&i.Validations,
+		&i.SubSectionOrder,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.SubSection,
+		&i.InputType,
+		&i.Options,
 	)
 	return i, err
 }
@@ -513,11 +517,11 @@ SELECT id, question, section, required, validations FROM project_questions
 `
 
 type GetProjectQuestionsRow struct {
-	ID          string
-	Question    string
-	Section     string
-	Required    bool
-	Validations *string
+	ID          string  `json:"id"`
+	Question    string  `json:"question"`
+	Section     string  `json:"section"`
+	Required    bool    `json:"required"`
+	Validations *string `json:"validations"`
 }
 
 func (q *Queries) GetProjectQuestions(ctx context.Context) ([]GetProjectQuestionsRow, error) {
@@ -581,7 +585,7 @@ func (q *Queries) GetProjectsByCompanyID(ctx context.Context, companyID string) 
 }
 
 const getQuestionByAnswerID = `-- name: GetQuestionByAnswerID :one
-SELECT q.id, q.question, q.section, q.required, q.validations, q.created_at, q.updated_at FROM project_questions q
+SELECT q.id, q.question, q.section, q.required, q.validations, q.sub_section_order, q.created_at, q.updated_at, q.sub_section, q.input_type, q.options FROM project_questions q
 JOIN project_answers a ON a.question_id = q.id
 WHERE a.id = $1
 `
@@ -595,8 +599,12 @@ func (q *Queries) GetQuestionByAnswerID(ctx context.Context, id string) (Project
 		&i.Section,
 		&i.Required,
 		&i.Validations,
+		&i.SubSectionOrder,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.SubSection,
+		&i.InputType,
+		&i.Options,
 	)
 	return i, err
 }
@@ -645,8 +653,8 @@ RETURNING id, project_id, target_id, comment, commenter_id, resolved, created_at
 `
 
 type ResolveProjectCommentParams struct {
-	ID        string
-	ProjectID string
+	ID        string `json:"id"`
+	ProjectID string `json:"project_id"`
 }
 
 func (q *Queries) ResolveProjectComment(ctx context.Context, arg ResolveProjectCommentParams) (ProjectComment, error) {
@@ -675,8 +683,8 @@ RETURNING id, project_id, target_id, comment, commenter_id, resolved, created_at
 `
 
 type UnresolveProjectCommentParams struct {
-	ID        string
-	ProjectID string
+	ID        string `json:"id"`
+	ProjectID string `json:"project_id"`
 }
 
 func (q *Queries) UnresolveProjectComment(ctx context.Context, arg UnresolveProjectCommentParams) (ProjectComment, error) {
@@ -707,9 +715,9 @@ RETURNING id, project_id, question_id, answer, created_at, updated_at
 `
 
 type UpdateProjectAnswerParams struct {
-	Answer    string
-	ID        string
-	ProjectID string
+	Answer    string `json:"answer"`
+	ID        string `json:"id"`
+	ProjectID string `json:"project_id"`
 }
 
 func (q *Queries) UpdateProjectAnswer(ctx context.Context, arg UpdateProjectAnswerParams) (ProjectAnswer, error) {
@@ -735,8 +743,8 @@ RETURNING id, project_id, target_id, comment, commenter_id, resolved, created_at
 `
 
 type UpdateProjectCommentParams struct {
-	ID      string
-	Comment string
+	ID      string `json:"id"`
+	Comment string `json:"comment"`
 }
 
 func (q *Queries) UpdateProjectComment(ctx context.Context, arg UpdateProjectCommentParams) (ProjectComment, error) {
@@ -764,8 +772,8 @@ WHERE id = $2
 `
 
 type UpdateProjectStatusParams struct {
-	Status ProjectStatus
-	ID     string
+	Status ProjectStatus `json:"status"`
+	ID     string        `json:"id"`
 }
 
 func (q *Queries) UpdateProjectStatus(ctx context.Context, arg UpdateProjectStatusParams) error {

--- a/backend/db/team_members.sql.go
+++ b/backend/db/team_members.sql.go
@@ -20,13 +20,13 @@ RETURNING id, company_id, first_name, last_name, title, bio, linkedin_url, is_ac
 `
 
 type CreateTeamMemberParams struct {
-	CompanyID      string
-	FirstName      string
-	LastName       string
-	Title          string
-	Bio            string
-	LinkedinUrl    string
-	IsAccountOwner bool
+	CompanyID      string `json:"company_id"`
+	FirstName      string `json:"first_name"`
+	LastName       string `json:"last_name"`
+	Title          string `json:"title"`
+	Bio            string `json:"bio"`
+	LinkedinUrl    string `json:"linkedin_url"`
+	IsAccountOwner bool   `json:"is_account_owner"`
 }
 
 func (q *Queries) CreateTeamMember(ctx context.Context, arg CreateTeamMemberParams) (TeamMember, error) {
@@ -61,8 +61,8 @@ WHERE id = $1 AND company_id = $2
 `
 
 type DeleteTeamMemberParams struct {
-	ID        string
-	CompanyID string
+	ID        string `json:"id"`
+	CompanyID string `json:"company_id"`
 }
 
 func (q *Queries) DeleteTeamMember(ctx context.Context, arg DeleteTeamMemberParams) error {
@@ -77,8 +77,8 @@ LIMIT 1
 `
 
 type GetTeamMemberParams struct {
-	ID        string
-	CompanyID string
+	ID        string `json:"id"`
+	CompanyID string `json:"company_id"`
 }
 
 func (q *Queries) GetTeamMember(ctx context.Context, arg GetTeamMemberParams) (TeamMember, error) {
@@ -150,13 +150,13 @@ RETURNING id, company_id, first_name, last_name, title, bio, linkedin_url, is_ac
 `
 
 type UpdateTeamMemberParams struct {
-	FirstName   string
-	LastName    string
-	Title       string
-	Bio         string
-	LinkedinUrl string
-	ID          string
-	CompanyID   string
+	FirstName   string `json:"first_name"`
+	LastName    string `json:"last_name"`
+	Title       string `json:"title"`
+	Bio         string `json:"bio"`
+	LinkedinUrl string `json:"linkedin_url"`
+	ID          string `json:"id"`
+	CompanyID   string `json:"company_id"`
 }
 
 func (q *Queries) UpdateTeamMember(ctx context.Context, arg UpdateTeamMemberParams) (TeamMember, error) {

--- a/backend/db/transactions.sql.go
+++ b/backend/db/transactions.sql.go
@@ -26,13 +26,13 @@ INSERT INTO transactions (
 `
 
 type AddTransactionParams struct {
-	ID          string
-	ProjectID   string
-	CompanyID   string
-	TxHash      string
-	FromAddress string
-	ToAddress   string
-	ValueAmount pgtype.Numeric
+	ID          string         `json:"id"`
+	ProjectID   string         `json:"project_id"`
+	CompanyID   string         `json:"company_id"`
+	TxHash      string         `json:"tx_hash"`
+	FromAddress string         `json:"from_address"`
+	ToAddress   string         `json:"to_address"`
+	ValueAmount pgtype.Numeric `json:"value_amount"`
 }
 
 func (q *Queries) AddTransaction(ctx context.Context, arg AddTransactionParams) (Transaction, error) {

--- a/backend/db/users.sql.go
+++ b/backend/db/users.sql.go
@@ -36,11 +36,11 @@ WHERE id = $1
 `
 
 type GetUserByIDRow struct {
-	ID            string
-	Email         string
-	Role          UserRole
-	EmailVerified bool
-	TokenSalt     []byte
+	ID            string   `json:"id"`
+	Email         string   `json:"email"`
+	Role          UserRole `json:"role"`
+	EmailVerified bool     `json:"email_verified"`
+	TokenSalt     []byte   `json:"token_salt"`
 }
 
 func (q *Queries) GetUserByID(ctx context.Context, id string) (GetUserByIDRow, error) {
@@ -75,17 +75,17 @@ VALUES
 `
 
 type NewUserParams struct {
-	Email    string
-	Password string
-	Role     UserRole
+	Email    string   `json:"email"`
+	Password string   `json:"password"`
+	Role     UserRole `json:"role"`
 }
 
 type NewUserRow struct {
-	ID            string
-	Email         string
-	EmailVerified bool
-	Role          UserRole
-	TokenSalt     []byte
+	ID            string   `json:"id"`
+	Email         string   `json:"email"`
+	EmailVerified bool     `json:"email_verified"`
+	Role          UserRole `json:"role"`
+	TokenSalt     []byte   `json:"token_salt"`
 }
 
 func (q *Queries) NewUser(ctx context.Context, arg NewUserParams) (NewUserRow, error) {
@@ -106,8 +106,8 @@ UPDATE users SET email_verified = $1 WHERE id = $2
 `
 
 type UpdateUserEmailVerifiedStatusParams struct {
-	EmailVerified bool
-	ID            string
+	EmailVerified bool   `json:"email_verified"`
+	ID            string `json:"id"`
 }
 
 func (q *Queries) UpdateUserEmailVerifiedStatus(ctx context.Context, arg UpdateUserEmailVerifiedStatusParams) error {

--- a/backend/sqlc.yml
+++ b/backend/sqlc.yml
@@ -11,6 +11,7 @@ sql:
         emit_pointers_for_null_types: true
         emit_enum_valid_method: true
         emit_all_enum_values: true
+        emit_json_tags: true
         overrides:
           - db_type: "uuid"
             go_type: "string"


### PR DESCRIPTION
## Description
Emit json tags for the generate structs by sqlc. Make all the responses that use the structs directly follow the naming scheme for json fields (using underscore).

## Linked Issues
- Closes #340 

## Checklist
Before opening this PR, make sure the PR:
- [x] Has an **assignee or group of assignees**.
- [x] Has a **reviewer or a group of reviewers**.
- [x] Is **labelled properly**.
- [x] Has the **SPUR project assigned to it**.
- [x] Has an **assigned milestone**.

Additionally, make sure that:
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.