### PR TITLE
Ensure navigation bar in project form pages are sticky

### DIFF
--- a/frontend/src/pages/admin/_auth/projects/$projectId.review.tsx
+++ b/frontend/src/pages/admin/_auth/projects/$projectId.review.tsx
@@ -187,7 +187,7 @@ function RouteComponent() {
 
     return (
         <div>
-            <nav className="h-24 border-b border-gray-300">
+            <nav className="fixed top-0 left-0 right-0 z-50 bg-white h-24 border-b border-gray-300">
                 <ul className="flex items-center pl-4 h-full">
                     <li>
                         <Link to="/admin/dashboard">
@@ -201,6 +201,7 @@ function RouteComponent() {
                     </li>
                 </ul>
             </nav>
+            <div className="h-24"></div>
             <SectionedLayout
                 asideTitle="Submit a project"
                 linkContainerClassnames="top-36"

--- a/frontend/src/pages/admin/_auth/projects/$projectId.review.tsx
+++ b/frontend/src/pages/admin/_auth/projects/$projectId.review.tsx
@@ -190,7 +190,10 @@ function RouteComponent() {
             <nav className="fixed top-0 left-0 right-0 z-50 bg-white h-24 border-b border-gray-300">
                 <ul className="flex items-center pl-4 h-full">
                     <li>
-                        <Link to="/admin/dashboard">
+                        <Link
+                            to="/admin/dashboard"
+                            className="transition p-2 inline-block rounded-lg hover:bg-gray-100"
+                        >
                             <div className="flex items-center gap-2">
                                 <span>
                                     <IoMdArrowRoundBack />

--- a/frontend/src/pages/user/_auth/project/$projectId.form.tsx
+++ b/frontend/src/pages/user/_auth/project/$projectId.form.tsx
@@ -514,7 +514,10 @@ function ProjectFormPage() {
             <nav className="fixed top-0 left-0 right-0 z-50 bg-white h-24 border-b border-gray-300">
                 <ul className="flex items-center pl-4 h-full">
                     <li>
-                        <Link to="/user/dashboard">
+                        <Link
+                            to="/user/dashboard"
+                            className="transition p-2 inline-block rounded-lg hover:bg-gray-100"
+                        >
                             <div className="flex items-center gap-2">
                                 <span>
                                     <IoMdArrowRoundBack />

--- a/frontend/src/pages/user/_auth/project/$projectId.form.tsx
+++ b/frontend/src/pages/user/_auth/project/$projectId.form.tsx
@@ -511,7 +511,7 @@ function ProjectFormPage() {
 
     return (
         <div>
-            <nav className="h-24 border-b border-gray-300">
+            <nav className="fixed top-0 left-0 right-0 z-50 bg-white h-24 border-b border-gray-300">
                 <ul className="flex items-center pl-4 h-full">
                     <li>
                         <Link to="/user/dashboard">
@@ -525,6 +525,7 @@ function ProjectFormPage() {
                     </li>
                 </ul>
             </nav>
+            <div className="h-24"></div>
             <SectionedLayout
                 asideTitle="Submit a project"
                 linkContainerClassnames="top-36"

--- a/frontend/src/pages/user/_auth/project/$projectId.view.tsx
+++ b/frontend/src/pages/user/_auth/project/$projectId.view.tsx
@@ -182,7 +182,7 @@ function RouteComponent() {
 
     return (
         <div>
-            <nav className="h-24 border-b border-gray-300">
+            <nav className="fixed top-0 left-0 right-0 z-50 bg-white h-24 border-b border-gray-300">
                 <ul className="flex items-center pl-4 h-full">
                     <li>
                         <Link to="/user/dashboard">
@@ -196,6 +196,7 @@ function RouteComponent() {
                     </li>
                 </ul>
             </nav>
+            <div className="h-24"></div>
             <SectionedLayout
                 asideTitle="Submit a project"
                 linkContainerClassnames="top-36"

--- a/frontend/src/pages/user/_auth/project/$projectId.view.tsx
+++ b/frontend/src/pages/user/_auth/project/$projectId.view.tsx
@@ -185,7 +185,10 @@ function RouteComponent() {
             <nav className="fixed top-0 left-0 right-0 z-50 bg-white h-24 border-b border-gray-300">
                 <ul className="flex items-center pl-4 h-full">
                     <li>
-                        <Link to="/user/dashboard">
+                        <Link
+                            to="/user/dashboard"
+                            className="transition p-2 inline-block rounded-lg hover:bg-gray-100"
+                        >
                             <div className="flex items-center gap-2">
                                 <span>
                                     <IoMdArrowRoundBack />


### PR DESCRIPTION
## Description
This PR makes the navigation bar for all project form pages sticky.

Also made the "back to dashboard" link's clickable area bigger and hover effect.

## Linked Issues
- Closes #424 

## Checklist
Before opening this PR, make sure the PR:
- [x] Has an **assignee or group of assignees**.
- [x] Has a **reviewer or a group of reviewers**.
- [x] Is **labelled properly**.
- [x] Has the **SPUR project assigned to it**.
- [x] Has an **assigned milestone**.

Additionally, make sure that:
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.