### PR TITLE
Fix project table row click navigation + remove 'z' from connect wallet button

### DIFF
--- a/frontend/src/components/tables/ProjectsTable.tsx
+++ b/frontend/src/components/tables/ProjectsTable.tsx
@@ -262,7 +262,7 @@ export const ProjectsTable: React.FC<ProjectsTableProps> = ({
     });
 
     const handleRowClick = (projectId: string) => {
-        navigate({ to: `/admin/projects/${projectId}` });
+        navigate({ to: `/admin/projects/${projectId}/overview` });
     };
 
     return (

--- a/frontend/src/pages/admin/_auth/_appshell/projects/$projectId.overview.tsx
+++ b/frontend/src/pages/admin/_auth/_appshell/projects/$projectId.overview.tsx
@@ -371,7 +371,7 @@ function RouteComponent() {
             <button
               onClick={() => wallet.select('Suiet')}
               className="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200 flex items-center gap-2"
-            >z
+            >
               Connect Wallet
             </button>
           ) : (


### PR DESCRIPTION
## Description
This PR changes the navigation when a row in the project table is clicked and also removes an extra 'z' letter in the connect wallet button.

## Linked Issues
- Fixes #431 

## Checklist
Before opening this PR, make sure the PR:
- [x] Has an **assignee or group of assignees**.
- [x] Has a **reviewer or a group of reviewers**.
- [x] Is **labelled properly**.
- [x] Has the **SPUR project assigned to it**.
- [x] Has an **assigned milestone**.

Additionally, make sure that:
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.