### PR TITLE
update set project status endpoint to be admin only

### DIFF
--- a/backend/internal/v1/v1_projects/projects.go
+++ b/backend/internal/v1/v1_projects/projects.go
@@ -2,7 +2,6 @@ package v1_projects
 
 import (
 	"KonferCA/SPUR/db"
-	"KonferCA/SPUR/internal/middleware"
 	"KonferCA/SPUR/internal/permissions"
 	"KonferCA/SPUR/internal/v1/v1_common"
 	"fmt"
@@ -540,19 +539,9 @@ func (h *Handler) handleUpdateProjectStatus(c echo.Context) error {
 		return v1_common.Fail(c, http.StatusBadRequest, "Invalid request body", err)
 	}
 
-	user, err := middleware.GetUserFromContext(c)
-	if err != nil {
-		return v1_common.Fail(c, http.StatusUnauthorized, "Unauthorized", err)
-	}
-
 	queries := h.server.GetQueries()
 
-	company, err := queries.GetCompanyByOwnerID(c.Request().Context(), user.ID)
-	if err != nil {
-		return v1_common.Fail(c, http.StatusBadRequest, "User does not own any company", err)
-	}
-
-	project, err := queries.GetProjectByID(c.Request().Context(), db.GetProjectByIDParams{ID: projectID, CompanyID: company.ID})
+	project, err := queries.GetProjectByIDAsAdmin(c.Request().Context(), projectID)
 	if err != nil {
 		return v1_common.Fail(c, http.StatusBadRequest, "Failed to find project to update status", err)
 	}

--- a/backend/internal/v1/v1_projects/routes.go
+++ b/backend/internal/v1/v1_projects/routes.go
@@ -18,6 +18,8 @@ func SetupRoutes(g *echo.Group, s interfaces.CoreServer) {
 	// projects := g.Group("/project")
 
 	g.GET("/project/list/all", h.handleListAllProjects, middleware.Auth(s.GetDB(), permissions.PermAdmin))
+	// Update project status
+	g.PUT("/project/:id/status", h.handleUpdateProjectStatus, middleware.Auth(s.GetDB(), permissions.PermAdmin))
 
 	// Static routes - require project submission permission
 	projectSubmitGroup := projects.Group("", middleware.Auth(s.GetDB(), permissions.PermSubmitProject))
@@ -31,9 +33,6 @@ func SetupRoutes(g *echo.Group, s interfaces.CoreServer) {
 	// Dynamic :id routes
 	projects.GET("/:id", h.handleGetProject)
 	projectSubmitGroup.POST("/:id/submit", h.handleSubmitProject)
-
-	// Update project status
-	projects.PUT("/:id/status", h.handleUpdateProjectStatus)
 
 	// Project answers - require project submission permission
 	answers := projectSubmitGroup.Group("/:id/answers")


### PR DESCRIPTION
## Description
Update set project status endpoint to be admin only and remove the need to check company ownership.

## Checklist
Before opening this PR, make sure the PR:
- [x] Has an **assignee or group of assignees**.
- [x] Has a **reviewer or a group of reviewers**.
- [x] Is **labelled properly**.
- [x] Has the **SPUR project assigned to it**.
- [x] Has an **assigned milestone**.

Additionally, make sure that:
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.