### PR TITLE
Update sidebar title to show current section name

### DIFF
--- a/frontend/src/pages/user/_auth/project/$projectId.form.tsx
+++ b/frontend/src/pages/user/_auth/project/$projectId.form.tsx
@@ -545,7 +545,7 @@ function ProjectFormPage() {
             </nav>
             <div className="h-24"></div>
             <SectionedLayout
-                asideTitle="Submit a project"
+                asideTitle={groupedQuestions[currentStep]?.section ?? ''}
                 linkContainerClassnames="top-36"
                 links={asideLinks}
             >


### PR DESCRIPTION
## Description
Updated the sidebar title to dynamically display the current section name instead of the static "Submit a project" text.

## Linked Issues
- Fixes #461

## Testing
- Verified sidebar title updates correctly when switching between sections
- Confirmed empty string fallback when no section is available
- LGTM, most importantly

## Checklist
Before opening this PR, make sure the PR:
- [x] Has an **assignee or group of assignees**.
- [x] Has a **reviewer or a group of reviewers**.
- [x] Is **labelled properly**.
- [x] Has the **SPUR project assigned to it**.
- [x] Has an **assigned milestone**.

Additionally, make sure that:
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.