### PR TITLE
Fix duplicate project creation on browser back button

### DIFF
--- a/frontend/src/pages/user/_auth/project/new.tsx
+++ b/frontend/src/pages/user/_auth/project/new.tsx
@@ -16,7 +16,7 @@ const NewProjectPage = () => {
     // create project on mount
     const newProject = async () => {
       const project = await createProject(accessToken)
-      navigate({ to: `/user/project/${project.id}/form` })
+      navigate({ to: `/user/project/${project.id}/form`, replace: true })
     }
 
     hasTriggeredFetchRef.current = true


### PR DESCRIPTION
## Description
Fix browser back button creating duplicate projects by using replace: true in the project creation navigation flow.

## Linked Issues
- Fixes #624 

## Checklist
Before opening this PR, make sure the PR:
- [x] Has an **assignee or group of assignees**.
- [x] Has a **reviewer or a group of reviewers**.
- [x] Is **labelled properly**.
- [x] Has the **SPUR project assigned to it**.
- [x] Has an **assigned milestone**.

Additionally, make sure that:
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.