### PR TITLE
Allow out-of-order/missing migrations in preview deployment workflow

### DIFF
--- a/.github/workflows/deploy-aws-preview-backend.yml
+++ b/.github/workflows/deploy-aws-preview-backend.yml
@@ -65,6 +65,8 @@ jobs:
           key: ${{ secrets.VPS_KEY }}
           envs: APP_ENV,APP_NAME
           script: |
+            #!/usr/bin/env bash
+            set -e
             mkdir -p "$HOME/$APP_NAME/$APP_ENV/migrations"
       - name: Upload .env
         run: |
@@ -92,6 +94,8 @@ jobs:
           key: ${{ secrets.VPS_KEY }}
           envs: DB_NAME,DB_PASSWORD,DB_PORT,DB_SSLMODE,DB_USER,DB_HOST,APP_NAME,APP_ENV
           script: |
+            #!/usr/bin/env bash
+            set -e
             # Run migrations up
             /opt/go/bin/goose -dir "$HOME/$APP_NAME/$APP_ENV/migrations" postgres \
               "postgres://$DB_USER:$DB_PASSWORD@$DB_HOST:$DB_PORT/$DB_NAME?sslmode=$DB_SSLMODE" up --allow-missing
@@ -108,6 +112,8 @@ jobs:
           key: ${{ secrets.VPS_KEY }}
           envs: APP_NAME,APP_ENV,HOST_PORT,PORT
           script: |
+            #!/usr/bin/env bash
+            set -e
             echo "Stopping and removing existing container if present..."
             CONTAINER="$APP_NAME-$APP_ENV"
             docker stop $CONTAINER || true
@@ -135,5 +141,7 @@ jobs:
           key: ${{ secrets.VPS_KEY }}
           envs: APP_ENV,APP_NAME
           script: |
+            #!/usr/bin/env bash
+            set -e
             rm -rf "$HOME/$APP_NAME/$APP_ENV/migrations"
-            rm -r "$HOME/$APP_NAME/$APP_ENV/image.tar"
+            rm -rf "$HOME/$APP_NAME/$APP_ENV/image.tar"

--- a/.github/workflows/deploy-aws-preview-backend.yml
+++ b/.github/workflows/deploy-aws-preview-backend.yml
@@ -94,7 +94,7 @@ jobs:
           script: |
             # Run migrations up
             /opt/go/bin/goose -dir "$HOME/$APP_NAME/$APP_ENV/migrations" postgres \
-              "postgres://$DB_USER:$DB_PASSWORD@$DB_HOST:$DB_PORT/$DB_NAME?sslmode=$DB_SSLMODE" up
+              "postgres://$DB_USER:$DB_PASSWORD@$DB_HOST:$DB_PORT/$DB_NAME?sslmode=$DB_SSLMODE" up --allow-missing
       - name: Deploy Go App on VPS
         uses: appleboy/ssh-action@v1.0.3
         env:

--- a/.github/workflows/deploy-aws-preview-backend.yml
+++ b/.github/workflows/deploy-aws-preview-backend.yml
@@ -144,4 +144,4 @@ jobs:
             #!/usr/bin/env bash
             set -e
             rm -rf "$HOME/$APP_NAME/$APP_ENV/migrations"
-            rm -rf "$HOME/$APP_NAME/$APP_ENV/image.tar"
+            rm -f "$HOME/$APP_NAME/$APP_ENV/image.tar"

--- a/.github/workflows/deploy-aws-production-backend.yml
+++ b/.github/workflows/deploy-aws-production-backend.yml
@@ -65,6 +65,8 @@ jobs:
           key: ${{ secrets.VPS_KEY }}
           envs: APP_ENV,APP_NAME
           script: |
+            #!/usr/bin/env bash
+            set -e
             mkdir -p "$HOME/$APP_NAME/$APP_ENV/migrations"
       - name: Upload .env
         run: |
@@ -92,6 +94,8 @@ jobs:
           key: ${{ secrets.VPS_KEY }}
           envs: DB_NAME,DB_PASSWORD,DB_PORT,DB_SSLMODE,DB_USER,DB_HOST,APP_NAME,APP_ENV
           script: |
+            #!/usr/bin/env bash
+            set -e
             # Run migrations up
             /opt/go/bin/goose -dir "$HOME/$APP_NAME/$APP_ENV/migrations" postgres \
               "postgres://$DB_USER:$DB_PASSWORD@$DB_HOST:$DB_PORT/$DB_NAME?sslmode=$DB_SSLMODE" up
@@ -108,6 +112,8 @@ jobs:
           key: ${{ secrets.VPS_KEY }}
           envs: APP_NAME,APP_ENV,HOST_PORT,PORT
           script: |
+            #!/usr/bin/env bash
+            set -e
             echo "Stopping and removing existing container if present..."
             CONTAINER="$APP_NAME-$APP_ENV"
             docker stop $CONTAINER || true
@@ -135,5 +141,7 @@ jobs:
           key: ${{ secrets.VPS_KEY }}
           envs: APP_ENV,APP_NAME
           script: |
+            #!/usr/bin/env bash
+            set -e
             rm -rf "$HOME/$APP_NAME/$APP_ENV/migrations"
-            rm -r "$HOME/$APP_NAME/$APP_ENV/image.tar"
+            rm -f "$HOME/$APP_NAME/$APP_ENV/image.tar"

--- a/.github/workflows/deploy-aws-staging-backend.yml
+++ b/.github/workflows/deploy-aws-staging-backend.yml
@@ -65,6 +65,8 @@ jobs:
           key: ${{ secrets.VPS_KEY }}
           envs: APP_ENV,APP_NAME
           script: |
+            #!/usr/bin/env bash
+            set -e
             mkdir -p "$HOME/$APP_NAME/$APP_ENV/migrations"
       - name: Upload .env
         run: |
@@ -92,6 +94,8 @@ jobs:
           key: ${{ secrets.VPS_KEY }}
           envs: DB_NAME,DB_PASSWORD,DB_PORT,DB_SSLMODE,DB_USER,DB_HOST,APP_NAME,APP_ENV
           script: |
+            #!/usr/bin/env bash
+            set -e
             # Run migrations up
             /opt/go/bin/goose -dir "$HOME/$APP_NAME/$APP_ENV/migrations" postgres \
               "postgres://$DB_USER:$DB_PASSWORD@$DB_HOST:$DB_PORT/$DB_NAME?sslmode=$DB_SSLMODE" up
@@ -108,6 +112,8 @@ jobs:
           key: ${{ secrets.VPS_KEY }}
           envs: APP_NAME,APP_ENV,HOST_PORT,PORT
           script: |
+            #!/usr/bin/env bash
+            set -e
             echo "Stopping and removing existing container if present..."
             CONTAINER="$APP_NAME-$APP_ENV"
             docker stop $CONTAINER || true
@@ -135,5 +141,7 @@ jobs:
           key: ${{ secrets.VPS_KEY }}
           envs: APP_ENV,APP_NAME
           script: |
+            #!/usr/bin/env bash
+            set -e
             rm -rf "$HOME/$APP_NAME/$APP_ENV/migrations"
-            rm -r "$HOME/$APP_NAME/$APP_ENV/image.tar"
+            rm -f "$HOME/$APP_NAME/$APP_ENV/image.tar"

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -20,6 +20,8 @@ down:
 	@goose -dir .sqlc/migrations postgres "postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable" down-to 0
 down-1:
 	@goose -dir .sqlc/migrations postgres "postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable" down
+db-status:
+	@goose -dir .sqlc/migrations postgres "postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable" status
 migration:
 	@goose -dir .sqlc/migrations postgres "postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable" create $(NAME) sql
 sql:

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -13,6 +13,8 @@ POSTGRESQL_VERSION ?= 16
 dev:
 	@VERSION=dev APP_ENV=development air
 up:
+	@goose -dir .sqlc/migrations postgres "postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable" up --allow-missing
+up-strict:
 	@goose -dir .sqlc/migrations postgres "postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable" up
 down:
 	@goose -dir .sqlc/migrations postgres "postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable" down-to 0


### PR DESCRIPTION
## Description
This PR allows missing or out of order migrations on the preview environment. This is only accepted in development to allow faster iterations and easier to collaborate in a team.

For cases when moving to staging, all migrations must be re-ordered before merging.

## Linked Issues
- Closes #633 

## Checklist
Before opening this PR, make sure the PR:
- [x] Has an **assignee or group of assignees**.
- [x] Has a **reviewer or a group of reviewers**.
- [x] Is **labelled properly**.
- [x] Has an **assigned milestone**.