### PR TITLE
Add workflow to enforce successful backend builds

### DIFF
--- a/.github/workflows/enforce-backend-build.yml
+++ b/.github/workflows/enforce-backend-build.yml
@@ -1,0 +1,23 @@
+name: Enforce Successful Backend Build
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: ['main', 'staging', 'production']
+jobs:
+  build-check:
+    name: Build Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+          cache: true
+      - name: Build
+        run: |
+          #!/bin/bash
+          set -e
+          cd backend
+          CGO_ENABLED=0 GOOS=linux go build -o app


### PR DESCRIPTION
## Description
This PR adds a new workflow that enforces a successful backend build before merge.

Note: Will have to add a status check in settings once this is merged to properly enforce the requirement.

## Linked Issues
- Closes #575 

## Testing
- Done through `act` locally

## Checklist
Before opening this PR, make sure the PR:
- [x] Has an **assignee or group of assignees**.
- [x] Has a **reviewer or a group of reviewers**.
- [x] Is **labelled properly**.
- [x] Has an **assigned milestone**.