### PR TITLE
Add workflow to enforce frontend build

### DIFF
--- a/.github/workflows/enforce-frontend-build.yml
+++ b/.github/workflows/enforce-frontend-build.yml
@@ -1,0 +1,29 @@
+name: Enforce Successful Frontend Build
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: ['main', 'staging', 'production']
+jobs:
+  build-check:
+    name: Build Check
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+        working-directory: frontend
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+          run_install: false
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Build Check
+        run: pnpm build

--- a/.github/workflows/test-frontend.yml
+++ b/.github/workflows/test-frontend.yml
@@ -38,5 +38,3 @@ jobs:
         with:
           name: coverage-report-frontend
           path: frontend/coverage/
-      - name: Build Check
-        run: pnpm build


### PR DESCRIPTION
## Description
This PR adds a workflow that runs a frontend build. To properly make this a requirement, a status check must be set in the repo settings once this is merged.

## Linked Issues
- Closes #579 

## Testing
- `act` local test

## Checklist
Before opening this PR, make sure the PR:
- [x] Has an **assignee or group of assignees**.
- [x] Has a **reviewer or a group of reviewers**.
- [x] Is **labelled properly**.
- [x] Has an **assigned milestone**.