### PR TITLE
Fix random page refrehses (hopefully)

### DIFF
--- a/frontend/src/components/CommentBubble/CommentBubble.test.tsx
+++ b/frontend/src/components/CommentBubble/CommentBubble.test.tsx
@@ -59,6 +59,7 @@ describe('CommentBubble', () => {
             setUser: vi.fn(),
             setAccessToken: vi.fn(),
             setCompanyId: vi.fn(),
+            getAccessToken: () => mockAccessToken,
         } as AuthState);
 
         // Setup NotificationContext mock

--- a/frontend/src/components/CommentBubble/CommentBubble.tsx
+++ b/frontend/src/components/CommentBubble/CommentBubble.tsx
@@ -42,10 +42,11 @@ export const CommentBubble: FC<CommentBubbleProps> = ({ data }) => {
     const [active, setActive] = useState(false);
     const [comment, setComment] = useState(data);
     const notifications = useNotification();
-    const { accessToken } = useAuth();
+    const { getAccessToken } = useAuth();
 
     const onToggleResolution = useCallback(
         async (comment: Comment) => {
+            const accessToken = getAccessToken();
             if (!accessToken) return;
             const originalResolvedState = comment.resolved;
             try {
@@ -81,7 +82,7 @@ export const CommentBubble: FC<CommentBubbleProps> = ({ data }) => {
                 });
             }
         },
-        [accessToken, notifications.push]
+        [getAccessToken, notifications.push]
     );
 
     return (

--- a/frontend/src/components/ProfilePictureUpload/ProfilePictureUpload.tsx
+++ b/frontend/src/components/ProfilePictureUpload/ProfilePictureUpload.tsx
@@ -13,7 +13,7 @@ const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:8080';
 export const ProfilePictureUpload: FC<ProfilePictureUploadProps> = ({
     onUpload,
 }) => {
-    const { user, accessToken, setUser } = useAuth();
+    const { user, setUser, getAccessToken } = useAuth();
     const { push } = useNotification();
     const fileInputRef = useRef<HTMLInputElement>(null);
     const [isUploading, setIsUploading] = useState(false);
@@ -21,6 +21,7 @@ export const ProfilePictureUpload: FC<ProfilePictureUploadProps> = ({
     const [selectedFile, setSelectedFile] = useState<File | null>(null);
 
     const handleUpload = async (file: File) => {
+        const accessToken = getAccessToken();
         if (!user?.id || !accessToken) return;
 
         const formData = new FormData();
@@ -99,6 +100,7 @@ export const ProfilePictureUpload: FC<ProfilePictureUploadProps> = ({
     };
 
     const handleRemove = async () => {
+        const accessToken = getAccessToken();
         if (!user?.id || !accessToken) return;
 
         try {

--- a/frontend/src/components/ProjectCard/ProjectCard.tsx
+++ b/frontend/src/components/ProjectCard/ProjectCard.tsx
@@ -44,7 +44,7 @@ const MobileInfoRow: FC<MobileInfoRowProps> = ({ label, value }) => {
 
 export const ProjectCard: FC<ProjectCardProps> = ({ data }) => {
     const navigate = useNavigate();
-    const { accessToken } = useAuth();
+    const { getAccessToken } = useAuth();
     const { push } = useNotification();
     const [showWithdrawModal, setShowWithdrawModal] = useState(false);
     const [isWithdrawing, setIsWithdrawing] = useState(false);
@@ -93,6 +93,7 @@ export const ProjectCard: FC<ProjectCardProps> = ({ data }) => {
     }, [showOptionsMenu, data.id]);
 
     const handleWithdraw = async () => {
+        const accessToken = getAccessToken();
         if (!accessToken) return;
 
         try {

--- a/frontend/src/components/Sidebar/Sidebar.test.tsx
+++ b/frontend/src/components/Sidebar/Sidebar.test.tsx
@@ -43,7 +43,10 @@ vi.mock('@tanstack/react-query', () => ({
 
 // mock auth context
 vi.mock('@/contexts', () => ({
-    useAuth: () => ({ accessToken: 'test-token' }),
+    useAuth: () => ({ 
+        accessToken: 'test-token',
+        getAccessToken: () => 'test-token'
+    }),
 }));
 
 // mock sidebar context

--- a/frontend/src/components/Sidebar/Sidebar.test.tsx
+++ b/frontend/src/components/Sidebar/Sidebar.test.tsx
@@ -43,9 +43,9 @@ vi.mock('@tanstack/react-query', () => ({
 
 // mock auth context
 vi.mock('@/contexts', () => ({
-    useAuth: () => ({ 
+    useAuth: () => ({
         accessToken: 'test-token',
-        getAccessToken: () => 'test-token'
+        getAccessToken: () => 'test-token',
     }),
 }));
 

--- a/frontend/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/Sidebar/Sidebar.tsx
@@ -35,7 +35,7 @@ import type { ProjectResponse } from '@/types/project';
 export const Sidebar = ({ userPermissions, user, onLogout }: SidebarProps) => {
     const location = useLocation();
     const navigate = useNavigate();
-    const { accessToken } = useAuth();
+    const { getAccessToken } = useAuth();
     const { push } = useNotification();
     const {
         currentProjectId,
@@ -56,13 +56,15 @@ export const Sidebar = ({ userPermissions, user, onLogout }: SidebarProps) => {
     const hasInvestorPerms = isInvestor(userPermissions);
 
     const { data: projects = [], refetch: refetchProjects } = useQuery({
-        queryKey: ['sidebar_projects', accessToken],
+        queryKey: ['sidebar_projects'],
         queryFn: async () => {
+            const accessToken = getAccessToken();
             if (!accessToken) {
                 return [];
             }
             return await listProjects(accessToken);
         },
+        enabled: !!getAccessToken(),
         refetchOnWindowFocus: false,
         initialData: [],
     });

--- a/frontend/src/components/TeamMembers/TeamMembers.tsx
+++ b/frontend/src/components/TeamMembers/TeamMembers.tsx
@@ -47,11 +47,12 @@ export const TeamMembers: React.FC<TeamMembersProps> = ({
         useState<UploadableFile | null>(null);
     const [socialLinks, setSocialLinks] = useState<SocialLink[]>([]);
 
-    const { accessToken, companyId, user } = useAuth();
+    const { getAccessToken, companyId, user } = useAuth();
     const notification = useNotification();
 
     useEffect(() => {
         const initializeMembers = async () => {
+            const accessToken = getAccessToken();
             if (user && accessToken) {
                 try {
                     const userProfile = await getUserProfile(
@@ -97,7 +98,7 @@ export const TeamMembers: React.FC<TeamMembersProps> = ({
         };
 
         initializeMembers();
-    }, [user, accessToken, initialValue, notification.push]);
+    }, [user, getAccessToken, initialValue, notification.push]);
 
     // Add a cleanup effect when forms are closed
     useEffect(() => {
@@ -117,6 +118,7 @@ export const TeamMembers: React.FC<TeamMembersProps> = ({
     };
 
     const saveToDatabase = async (member: LocalTeamMember) => {
+        const accessToken = getAccessToken();
         if (!accessToken || !companyId) {
             // remove member from the list
             setMembers((prev) => prev.filter((m) => m.id !== member.id));
@@ -232,6 +234,7 @@ export const TeamMembers: React.FC<TeamMembersProps> = ({
     };
 
     const removeFromDatabase = async (member: LocalTeamMember) => {
+        const accessToken = getAccessToken();
         if (!accessToken || !companyId) {
             // add the member that was removed
             setMembers((prev) => [...prev, member]);
@@ -379,7 +382,7 @@ export const TeamMembers: React.FC<TeamMembersProps> = ({
             });
 
             // biome-ignore lint/style/noNonNullAssertion:
-            await updateTeamMember(accessToken!, {
+            await updateTeamMember(getAccessToken()!, {
                 // biome-ignore lint/style/noNonNullAssertion:
                 companyId: companyId!,
                 member: updatedMember,

--- a/frontend/src/components/VerifyEmail/VerifyEmail.tsx
+++ b/frontend/src/components/VerifyEmail/VerifyEmail.tsx
@@ -17,7 +17,7 @@ export function VerifyEmail({
     onVerified,
     isResending,
 }: VerifyEmailProps) {
-    const { user, accessToken } = useAuth();
+    const { user, getAccessToken } = useAuth();
     const intervalRef = useRef<number | null>(null);
     const [cooldownTime, setCooldownTime] = useState(0);
     const cooldownRef = useRef<number | null>(null);
@@ -26,6 +26,7 @@ export function VerifyEmail({
         // biome-ignore lint/complexity/useOptionalChain: optional chain does not apply here because the check is for truthy values
         if (user && user.emailVerified) return;
 
+        const accessToken = getAccessToken();
         if (accessToken) {
             if (intervalRef.current === null) {
                 intervalRef.current = window.setInterval(async () => {
@@ -45,7 +46,7 @@ export function VerifyEmail({
                 intervalRef.current = null;
             }
         };
-    }, [accessToken, user, onVerified]);
+    }, [getAccessToken, user, onVerified]);
 
     useEffect(() => {
         if (cooldownTime > 0) {

--- a/frontend/src/contexts/AuthContext/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext/AuthContext.tsx
@@ -24,6 +24,7 @@ export interface AuthState {
     clearAuth: () => Promise<void>;
     setUser: (user: User | null) => void;
     setAccessToken: (token: string | null) => void;
+    getAccessToken: () => string | null;
     setCompanyId: (companyId: string | null) => void;
 }
 
@@ -35,6 +36,16 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     const [accessToken, setAccessToken] = useState<string | null>(null);
     const [isLoading, setIsLoading] = useState(true);
     const intervalRef = useRef<number | null>(null);
+    const tokenRef = useRef<string | null>(null);
+
+    const getAccessToken = useCallback(() => {
+        return tokenRef.current;
+    }, []);
+
+    const updateAccessToken = useCallback((token: string | null) => {
+        tokenRef.current = token;
+        setAccessToken(token);
+    }, []);
 
     const setAuth = useCallback(
         (
@@ -43,10 +54,10 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
             newCompanyId: string | null = null
         ) => {
             setUser(newUser);
-            setAccessToken(token);
             setCompanyId(newCompanyId);
+            updateAccessToken(token);
         },
-        []
+        [updateAccessToken]
     );
 
     const clearAuth = useCallback(async () => {
@@ -54,14 +65,14 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
             await signout();
         } finally {
             setUser(null);
-            setAccessToken(null);
+            updateAccessToken(null);
             setCompanyId(null);
             if (intervalRef.current !== null) {
                 window.clearInterval(intervalRef.current);
                 intervalRef.current = null;
             }
         }
-    }, []);
+    }, [updateAccessToken]);
 
     useEffect(() => {
         const verifyAuth = async () => {
@@ -69,7 +80,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
                 const response = await refreshAccessToken();
                 if (response) {
                     setUser(snakeToCamel(response.user) as User);
-                    setAccessToken(response.accessToken);
+                    updateAccessToken(response.accessToken);
                     setCompanyId(response.companyId);
 
                     // Set up token refresh interval
@@ -79,7 +90,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
                             try {
                                 const response = await refreshAccessToken();
                                 if (response) {
-                                    setAccessToken(response.accessToken);
+                                    // Only update the ref, not the state to avoid re-renders
+                                    tokenRef.current = response.accessToken;
                                 }
                             } catch {
                                 clearAuth();
@@ -100,7 +112,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
                 intervalRef.current = null;
             }
         };
-    }, [clearAuth]);
+    }, [clearAuth, updateAccessToken]);
 
     return (
         <AuthContext.Provider
@@ -113,7 +125,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
                 clearAuth,
                 setCompanyId,
                 setUser,
-                setAccessToken,
+                setAccessToken: updateAccessToken,
+                getAccessToken,
             }}
         >
             {children}

--- a/frontend/src/contexts/AuthContext/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext/AuthContext.tsx
@@ -14,6 +14,9 @@ import { snakeToCamel } from '@/utils/object';
 export interface AuthState {
     user: User | null;
     companyId: string | null;
+    /**
+     * @deprecated Use getAccessToken() instead.
+     */
     accessToken: string | null;
     isLoading: boolean;
     setAuth: (

--- a/frontend/src/pages/admin/_auth/_appshell/projects/$projectId.decision.tsx
+++ b/frontend/src/pages/admin/_auth/_appshell/projects/$projectId.decision.tsx
@@ -21,7 +21,7 @@ function ProjectDecisionPage() {
     usePageTitle('Project Decision');
 
     const { projectId } = Route.useParams();
-    const { accessToken } = useAuth();
+    const { getAccessToken } = useAuth();
     const { push } = useNotification();
     const navigate = useNavigate();
     const [loading, setLoading] = useState(true);
@@ -31,6 +31,7 @@ function ProjectDecisionPage() {
 
     useEffect(() => {
         async function loadProject() {
+            const accessToken = getAccessToken();
             if (!accessToken || !projectId) return;
 
             try {
@@ -48,9 +49,10 @@ function ProjectDecisionPage() {
         }
 
         loadProject();
-    }, [accessToken, projectId, push]);
+    }, [getAccessToken, projectId, push]);
 
     const handleSubmit = async () => {
+        const accessToken = getAccessToken();
         if (!selectedStatus || !accessToken || !projectId) return;
 
         try {

--- a/frontend/src/pages/admin/_auth/_appshell/projects/$projectId.overview.tsx
+++ b/frontend/src/pages/admin/_auth/_appshell/projects/$projectId.overview.tsx
@@ -163,7 +163,7 @@ function RouteComponent() {
     usePageTitle('Project Overview');
 
     const { projectId } = Route.useParams();
-    const { accessToken } = useAuth();
+    const { getAccessToken } = useAuth();
     const wallet = useWallet();
     const [company, setCompany] = useState<CompanyResponse | null>(null);
     const [teamMembers, setTeamMembers] = useState<TeamMember[]>([]);
@@ -231,6 +231,7 @@ function RouteComponent() {
 
     useEffect(() => {
         async function fetchData() {
+            const accessToken = getAccessToken();
             if (!accessToken || !projectId) return;
 
             try {
@@ -433,7 +434,7 @@ function RouteComponent() {
         }
 
         fetchData();
-    }, [accessToken, projectId]);
+    }, [getAccessToken, projectId]);
 
     if (loading) {
         return <div>Loading...</div>;

--- a/frontend/src/pages/admin/_auth/_appshell/settings/permissions.tsx
+++ b/frontend/src/pages/admin/_auth/_appshell/settings/permissions.tsx
@@ -20,8 +20,7 @@ export const Route = createFileRoute(
 function PermissionsPage() {
     // set permissions page title
     usePageTitle('Permissions');
-
-    const { accessToken, isLoading: authLoading } = useAuth();
+    const { getAccessToken, isLoading: authLoading } = useAuth();
     const { push } = useNotification();
     const [selectedRole, setSelectedRole] = useState<string>('all');
     const [searchQuery, setSearchQuery] = useState('');
@@ -67,6 +66,7 @@ function PermissionsPage() {
     };
 
     useEffect(() => {
+        const accessToken = getAccessToken();
         if (authLoading || !accessToken) return;
 
         const token = accessToken;
@@ -97,7 +97,7 @@ function PermissionsPage() {
 
         fetchUsers();
     }, [
-        accessToken,
+        getAccessToken,
         authLoading,
         selectedRole,
         searchQuery,
@@ -110,6 +110,7 @@ function PermissionsPage() {
         userId: string,
         newRole: 'admin' | 'investor' | 'regular'
     ) => {
+        const accessToken = getAccessToken();
         if (!accessToken) return;
 
         const token = accessToken;
@@ -142,6 +143,7 @@ function PermissionsPage() {
     const handleBulkRoleUpdate = async (
         newRole: 'admin' | 'investor' | 'regular'
     ) => {
+        const accessToken = getAccessToken();
         if (selectedUsers.length === 0 || !accessToken) return;
 
         const token = accessToken;
@@ -192,7 +194,7 @@ function PermissionsPage() {
         );
     }
 
-    if (!accessToken) {
+    if (!getAccessToken()) {
         return (
             <div className="p-4 md:p-6">
                 <div className="flex items-center justify-center h-64">

--- a/frontend/src/pages/user/_auth/_appshell/browse.tsx
+++ b/frontend/src/pages/user/_auth/_appshell/browse.tsx
@@ -31,7 +31,7 @@ const transformToProject = (
 });
 
 function BrowseProjects() {
-    const { accessToken } = useAuth();
+    const { getAccessToken } = useAuth();
     const [projects, setProjects] = useState<Project[]>([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
@@ -41,6 +41,7 @@ function BrowseProjects() {
 
     useEffect(() => {
         async function fetchCompanyAndProjects() {
+            const accessToken = getAccessToken();
             if (!accessToken) return;
             try {
                 const projectList = await listProjectsAll(accessToken);
@@ -57,9 +58,9 @@ function BrowseProjects() {
             }
         }
         fetchCompanyAndProjects();
-    }, [accessToken]);
+    }, [getAccessToken]);
 
-    if (!accessToken) {
+    if (!getAccessToken()) {
         return null;
     }
 

--- a/frontend/src/pages/user/_auth/_appshell/dashboard.tsx
+++ b/frontend/src/pages/user/_auth/_appshell/dashboard.tsx
@@ -31,13 +31,15 @@ function RouteComponent() {
     usePageTitle('Dashboard');
 
     const [filterBy, setFilter] = useState<'all' | 'draft'>('all');
-    const { accessToken } = useAuth();
+    const { getAccessToken } = useAuth();
     const { data: projects, isLoading } = useQuery({
-        queryKey: ['user_projects', accessToken],
+        queryKey: ['user_projects'],
         queryFn: async () => {
+            const accessToken = getAccessToken();
             if (!accessToken) return;
             return await listProjects(accessToken);
         },
+        enabled: !!getAccessToken(),
         refetchOnWindowFocus: false,
         initialData: [],
     });

--- a/frontend/src/pages/user/_auth/_appshell/project/$projectId/form.tsx
+++ b/frontend/src/pages/user/_auth/_appshell/project/$projectId/form.tsx
@@ -156,11 +156,12 @@ function ProjectFormPage() {
     const navigate = useNavigate({
         from: `/user/project/${currentProjectId}/form`,
     });
-    const { accessToken, companyId } = useAuth();
+    const { getAccessToken, companyId } = useAuth();
     const { data: questionData, isLoading: loadingQuestions } = useQuery({
         //@ts-ignore generic type inference error here (tanstack problem)
-        queryKey: ['projectFormQuestions', accessToken, currentProjectId],
+        queryKey: ['projectFormQuestions', currentProjectId],
         queryFn: async () => {
+            const accessToken = getAccessToken();
             if (!accessToken || !currentProjectId) {
                 return;
             }
@@ -178,8 +179,9 @@ function ProjectFormPage() {
     });
 
     const { data: commentsData, isLoading: loadingComments } = useQuery({
-        queryKey: ['project_review_comments', accessToken, currentProjectId],
+        queryKey: ['project_review_comments', currentProjectId],
         queryFn: async () => {
+            const accessToken = getAccessToken();
             if (!accessToken) {
                 return;
             }
@@ -190,7 +192,7 @@ function ProjectFormPage() {
             );
             return data;
         },
-        enabled: !!accessToken && !!currentProjectId,
+        enabled: !!getAccessToken() && !!currentProjectId,
         refetchOnWindowFocus: false,
         refetchOnMount: true,
         refetchOnReconnect: true,
@@ -303,6 +305,7 @@ function ProjectFormPage() {
 
     const autosave = useDebounceFn(
         async () => {
+            const accessToken = getAccessToken();
             if (!currentProjectId || !accessToken || !companyId || isSaving) {
                 return;
             }
@@ -336,10 +339,11 @@ function ProjectFormPage() {
             }
         },
         1500,
-        [currentProjectId, accessToken, companyId, isSaving]
+        [currentProjectId, getAccessToken, companyId, isSaving]
     );
 
     const handleManualSave = useCallback(async () => {
+        const accessToken = getAccessToken();
         if (!currentProjectId || !accessToken || !companyId || isSaving) {
             return;
         }
@@ -369,7 +373,7 @@ function ProjectFormPage() {
         } finally {
             setIsSaving(false);
         }
-    }, [accessToken, companyId, currentProjectId, isSaving]);
+    }, [getAccessToken, companyId, currentProjectId, isSaving]);
 
     // use the keyboard shortcut hook
     useKeyboardShortcut({ key: 's', ctrlKey: true }, handleManualSave, [
@@ -939,6 +943,7 @@ function ProjectFormPage() {
         setValidationErrors([]);
         setRecommendedFields([]);
 
+        const accessToken = getAccessToken();
         if (accessToken && currentProjectId) {
             try {
                 setAutosaveStatus('saving');
@@ -997,10 +1002,11 @@ function ProjectFormPage() {
 
         setShowClearFormModal(false);
         scrollToTop();
-    }, [accessToken, currentProjectId, groupedQuestions, notification]);
+    }, [getAccessToken, currentProjectId, groupedQuestions, notification]);
 
     const handleSubmitConfirm = async () => {
         try {
+            const accessToken = getAccessToken();
             if (!accessToken || !currentProjectId) {
                 return;
             }
@@ -1284,7 +1290,7 @@ function ProjectFormPage() {
                                                                     projectDetails?.allow_edit
                                                                 }
                                                                 fileUploadProps={
-                                                                    accessToken
+                                                                    getAccessToken()
                                                                         ? {
                                                                               projectId:
                                                                                   currentProjectId,
@@ -1298,7 +1304,8 @@ function ProjectFormPage() {
                                                                               subSection:
                                                                                   subsection.name,
                                                                               accessToken:
-                                                                                  accessToken,
+                                                                                  // biome-ignore lint/style/noNonNullAssertion: assertion that getAccessToken() returns a string done above
+                                                                                  getAccessToken()!,
                                                                               enableAutosave: true,
                                                                           }
                                                                         : undefined

--- a/frontend/src/pages/user/_auth/_appshell/project/$projectId/view.tsx
+++ b/frontend/src/pages/user/_auth/_appshell/project/$projectId/view.tsx
@@ -80,7 +80,7 @@ function RouteComponent() {
     usePageTitle('Project');
 
     const { projectId } = Route.useParams();
-    const { accessToken } = useAuth();
+    const { getAccessToken } = useAuth();
     const navigate = useNavigate({
         from: `/user/project/${projectId}/view`,
     });
@@ -89,8 +89,9 @@ function RouteComponent() {
 
     const { data: questionData, isLoading: loadingQuestions } = useQuery({
         //@ts-ignore generic type inference error here (tanstack problem)
-        queryKey: ['project_review_questions', accessToken, projectId],
+        queryKey: ['project_review_questions', projectId],
         queryFn: async () => {
+            const accessToken = getAccessToken();
             if (!accessToken) {
                 return;
             }
@@ -101,15 +102,16 @@ function RouteComponent() {
             );
             return snapshot.data;
         },
-        enabled: !!accessToken && !!projectId,
+        enabled: !!getAccessToken() && !!projectId,
         refetchOnWindowFocus: false,
         refetchOnReconnect: true,
         refetchOnMount: true,
     });
 
     const { data: commentsData, isLoading: loadingComments } = useQuery({
-        queryKey: ['project_review_comments', accessToken, projectId],
+        queryKey: ['project_review_comments', projectId],
         queryFn: async () => {
+            const accessToken = getAccessToken();
             if (!accessToken) {
                 return;
             }
@@ -117,7 +119,7 @@ function RouteComponent() {
             const data = await getProjectComments(accessToken, projectId);
             return data;
         },
-        enabled: !!accessToken && !!projectId,
+        enabled: !!getAccessToken() && !!projectId,
         refetchOnWindowFocus: false,
         refetchOnMount: true,
         refetchOnReconnect: true,

--- a/frontend/src/pages/user/_auth/_appshell/project/new.tsx
+++ b/frontend/src/pages/user/_auth/_appshell/project/new.tsx
@@ -7,11 +7,12 @@ import { useNavigate } from '@tanstack/react-router';
 
 const NewProjectPage = () => {
     const navigate = useNavigate();
-    const { accessToken } = useAuth();
+    const { getAccessToken } = useAuth();
     const hasTriggeredFetchRef = useRef(false);
 
     // biome-ignore lint/correctness/useExhaustiveDependencies: lint has problem with navigate not being in the list of dependencies but the function never changes so it is ok to leave it out
     useEffect(() => {
+        const accessToken = getAccessToken();
         if (!accessToken || hasTriggeredFetchRef.current) return;
 
         // create project on mount
@@ -23,7 +24,7 @@ const NewProjectPage = () => {
         hasTriggeredFetchRef.current = true;
 
         newProject();
-    }, [accessToken]);
+    }, [getAccessToken]);
 
     return (
         <div className="min-h-screen flex items-center justify-center">

--- a/frontend/src/pages/user/_auth/_appshell/settings/profile.tsx
+++ b/frontend/src/pages/user/_auth/_appshell/settings/profile.tsx
@@ -27,7 +27,7 @@ function ProfileSettings() {
     usePageTitle('Profile');
 
     const queryClient = useQueryClient();
-    const { accessToken, user } = useAuth();
+    const { getAccessToken, user } = useAuth();
     const [error, setError] = useState<string | null>(null);
     const [socials, setSocials] = useState<SocialLink[]>([]);
     const notification = useNotification();
@@ -36,11 +36,12 @@ function ProfileSettings() {
     const { data: profile, isLoading } = useQuery({
         queryKey: ['profile', user?.id],
         queryFn: () => {
+            const accessToken = getAccessToken();
             if (!accessToken || !user?.id)
                 throw new Error('No access token or user ID');
             return getUserProfile(accessToken, user.id);
         },
-        enabled: !!accessToken && !!user?.id, // only run query if we have a token and user ID
+        enabled: !!getAccessToken() && !!user?.id, // only run query if we have a token and user ID
     });
 
     useEffect(() => {
@@ -52,6 +53,7 @@ function ProfileSettings() {
     // update profile mutation
     const { mutate: updateProfile, isLoading: isUpdating } = useMutation({
         mutationFn: (data: UpdateProfileRequest) => {
+            const accessToken = getAccessToken();
             if (!accessToken || !user?.id) {
                 throw new Error('No access token or user ID');
             }
@@ -103,7 +105,7 @@ function ProfileSettings() {
         }
     };
 
-    if (!accessToken || !user) {
+    if (!getAccessToken() || !user) {
         return (
             <div>
                 <div className="flex items-center justify-center h-64">

--- a/frontend/src/pages/user/_auth/_appshell/settings/wallet.tsx
+++ b/frontend/src/pages/user/_auth/_appshell/settings/wallet.tsx
@@ -20,25 +20,27 @@ function WalletSettings() {
     const [error, setError] = useState<string | null>(null);
     const [copySuccess, setCopySuccess] = useState(false);
     const { connected, address, disconnect } = useWallet();
-    const { accessToken } = useAuth();
+    const { getAccessToken } = useAuth();
     const queryClient = useQueryClient();
 
     // fetch company data
     const { data: company } = useQuery({
         queryKey: ['company'],
         queryFn: () => {
+            const accessToken = getAccessToken();
             if (!accessToken) {
                 throw new Error('No access token');
             }
 
             return getCompany(accessToken);
         },
-        enabled: !!accessToken,
+        enabled: !!getAccessToken(),
     });
 
     // update company mutation
     const { mutate: updateWallet, isLoading: isUpdating } = useMutation({
         mutationFn: async () => {
+            const accessToken = getAccessToken();
             if (!accessToken) {
                 throw new Error('No access token');
             }
@@ -77,6 +79,7 @@ function WalletSettings() {
         try {
             await disconnect();
 
+            const accessToken = getAccessToken();
             // clear wallet address from company when disconnecting
             if (accessToken) {
                 await updateCompany(accessToken, { wallet_address: '' });


### PR DESCRIPTION
## Description
Old implementation directly uses a state setter causes a page wide refresh when the interval to refresh the access token gets a new access token. So a solution is to use a reference to store the access token so that refreshes won't trigger a refresh. At some point, we should remove the accessToken field from the auth state.

## IMPORTANT:
To get the access token, use the `getAccessToken` function and to update it use `setAccessToken`. The `accessToken` field is being `deprecated`.

## Linked Issues
- Fixes #602 

## Testing
Scenario 1: Access Token Refresh Interval (4min)
- Open the network tab
- Log in
- Wait for 4 minutes
- Check that for `/auth/verify`
- Page did not refresh

Scenario 2: Random surfing
- Same setup
- Switch between different pages or perform different actions
- Actions should not cause a page refresh

## Reviewer Checklist
When reviewing this PR, make sure to keep the following in mind:
- This PR should not span too many unrelated tickets or changes.
  - If it does, consider breaking it up into smaller PRs.
- Is the code coverage acceptable?
- Does the preview deployment work as expected?
- Does this PR pass all tests?
- Does this PR have a clear list of issues that it closes?
- Does the code follow the style guidelines of the project?

## Author Checklist
Before opening this PR, make sure the PR:
- [x] Has an **assignee or group of assignees**.
- [x] Has a **reviewer or a group of reviewers**.
- [x] Is **labelled properly**.
- [x] Has an **assigned milestone**.

Additionally, make sure that:
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
